### PR TITLE
Update instructions for local execution with Docker

### DIFF
--- a/data/STRING11_species.csv
+++ b/data/STRING11_species.csv
@@ -1,0 +1,5091 @@
+species_id,official_name,compact_name,kingdom,type
+287,Pseudomonas aeruginosa,Pseudomonas aeruginosa,,core
+292,Burkholderia cepacia,Burkholderia cepacia,,core
+301,Pseudomonas oleovorans,Pseudomonas oleovorans,,core
+340,Xanthomonas campestris pv. campestris,Xanthomonas campestris campestris,,core
+359,Agrobacterium rhizogenes,Agrobacterium rhizogenes,,core
+394,Sinorhizobium fredii NGR234,Sinorhizobium fredii NGR234,,core
+470,Acinetobacter baumannii,Acinetobacter baumannii,,core
+511,Alcaligenes faecalis,Alcaligenes faecalis,,core
+549,Pantoea agglomerans,Pantoea agglomerans,,core
+571,Klebsiella oxytoca,Klebsiella oxytoca,,periphery
+573,Klebsiella pneumoniae,Klebsiella pneumoniae,,core
+585,Proteus vulgaris,Proteus vulgaris,,core
+633,Yersinia pseudotuberculosis,Yersinia pseudotuberculosis,,core
+672,Vibrio vulnificus,Vibrio vulnificus,,core
+747,Pasteurella multocida,Pasteurella multocida,,core
+758,Pasteurella pneumotropica,Pasteurella pneumotropica,,periphery
+813,Chlamydia trachomatis,Chlamydia trachomatis,,core
+827,Campylobacter ureolyticus,Campylobacter ureolyticus,,periphery
+882,Desulfovibrio vulgaris str. Hildenborough,Desulfovibrio vulgaris Hildenborough,,core
+883,Desulfovibrio vulgaris str. 'Miyazaki F',Desulfovibrio vulgaris Miyazaki,,periphery
+991,Flavobacterium hydatis,Flavobacterium hydatis,,core
+1044,Erythrobacter longus,Erythrobacter longus,,periphery
+1140,Synechococcus elongatus PCC7942,Synechococcus elongatus PCC7942,,core
+1147,Synechocystis sp. PCC6714,Synechocystis sp. PCC6714,,periphery
+1148,Synechocystis sp. PCC6803,Synechocystis sp. PCC6803,,core
+1246,Leuconostoc lactis,Leuconostoc lactis,,core
+1274,Dermacoccus nishinomiyaensis,Dermacoccus nishinomiyaensis,,core
+1280,Staphylococcus aureus,Staphylococcus aureus,,core
+1288,Staphylococcus xylosus,Staphylococcus xylosus,,core
+1314,Streptococcus pyogenes,Streptococcus pyogenes,,core
+1346,Streptococcus iniae,Streptococcus iniae,,periphery
+1396,Bacillus cereus,Bacillus cereus,,core
+1405,Bacillus mycoides,Bacillus mycoides,,periphery
+1507,Clostridium sp. ATCC29733,Clostridium sp. ATCC29733,,periphery
+1511,[Clostridium] sticklandii,Clostridium sticklandii,,periphery
+1605,Lactobacillus animalis,Lactobacillus animalis,,core
+1680,Bifidobacterium adolescentis,Bifidobacterium adolescentis,,core
+1687,Bifidobacterium coryneforme,Bifidobacterium coryneforme,,periphery
+1688,Bifidobacterium cuniculi,Bifidobacterium cuniculi,,periphery
+1690,Bifidobacterium pseudolongum subsp. globosum,Bifidobacterium pseudolongum globosum,,periphery
+1692,Bifidobacterium magnum,Bifidobacterium magnum,,periphery
+1693,Bifidobacterium minimum,Bifidobacterium minimum,,periphery
+1713,Oerskovia turbata,Oerskovia turbata,,core
+1719,Corynebacterium pseudotuberculosis,Corynebacterium pseudotuberculosis,,core
+1828,Rhodococcus fascians,Rhodococcus fascians,,periphery
+1869,Actinoplanes utahensis,Actinoplanes utahensis,,periphery
+1894,Streptomyces aureofaciens,Streptomyces aureofaciens,,core
+1896,Streptomyces bikiniensis,Streptomyces bikiniensis,,periphery
+1906,Streptomyces fradiae,Streptomyces fradiae,,core
+1907,Streptomyces glaucescens,Streptomyces glaucescens,,periphery
+1944,Streptomyces halstedii,Streptomyces halstedii,,periphery
+1957,Streptomyces sclerotialus,Streptomyces sclerotialus,,periphery
+1961,Streptomyces virginiae,Streptomyces virginiae,,periphery
+1968,Streptomyces cellulosae,Streptomyces cellulosae,,periphery
+1996,Microtetraspora glauca,Microtetraspora glauca,,periphery
+2002,Streptosporangium amethystogenes,Streptosporangium amethystogenes,,periphery
+2045,Pimelobacter simplex,Pimelobacter simplex,,core
+2055,Gordonia terrae,Gordonia terrae,,core
+2074,Pseudonocardia autotrophica,Pseudonocardia autotrophica,,periphery
+2110,Mycoplasma agalactiae,Mycoplasma agalactiae,,core
+2113,Mycoplasma californicum,Mycoplasma californicum,,core
+2325,Thermoanaerobacter kivui,Thermoanaerobacter kivui,,core
+2340,Solemya velum gill symbiont,Solemya velum,,core
+2342,Candidatus Sodalis pierantonius str. SOPE,Sodalis pierantonius,,periphery
+2423,Fervidobacterium islandicum,Fervidobacterium islandicum,,core
+2711,Citrus sinensis,Citrus sinensis,,periphery
+2754,Synergistes jonesii,Synergistes jonesii,,periphery
+2850,Phaeodactylum tricornutum,Phaeodactylum tricornutum,,core
+2880,Ectocarpus siliculosus,Ectocarpus siliculosus,,core
+2903,Emiliania huxleyi,Emiliania huxleyi,,core
+3055,Chlamydomonas reinhardtii,Chlamydomonas reinhardtii,,core
+3067,Volvox carteri,Volvox carteri,,periphery
+3075,Auxenochlorella protothecoides,Auxenochlorella protothecoides,,periphery
+3218,Physcomitrella patens,Physcomitrella patens,,core
+3641,Theobroma cacao,Theobroma cacao,,core
+3649,Carica papaya,Carica papaya,,periphery
+3656,Cucumis melo,Cucumis melo,,core
+3659,Cucumis sativus,Cucumis sativus,,periphery
+3694,Populus trichocarpa,Populus trichocarpa,,core
+3702,Arabidopsis thaliana,Arabidopsis thaliana,,core
+3711,Brassica rapa,Brassica rapa,,core
+3712,Brassica oleracea,Brassica oleracea,,periphery
+3750,Malus domestica,Malus domestica,,core
+3760,Prunus persica,Prunus persica,,periphery
+3827,Cicer arietinum,Cicer arietinum,,periphery
+3847,Glycine max,Glycine max,,core
+3880,Medicago truncatula,Medicago truncatula,,periphery
+3885,Phaseolus vulgaris,Phaseolus vulgaris,,core
+3983,Manihot esculenta,Manihot esculenta,,core
+3988,Ricinus communis,Ricinus communis,,periphery
+4006,Linum usitatissimum,Linum usitatissimum,,periphery
+4081,Solanum lycopersicum,Solanum lycopersicum,,core
+4096,Nicotiana sylvestris,Nicotiana sylvestris,,periphery
+4098,Nicotiana tomentosiformis,Nicotiana tomentosiformis,,periphery
+4113,Solanum tuberosum,Solanum tuberosum,,core
+4155,Erythranthe guttata,Erythranthe guttata,,core
+4432,Nelumbo nucifera,Nelumbo nucifera,,core
+4513,Hordeum vulgare,Hordeum vulgare,,core
+4529,Oryza rufipogon,Oryza rufipogon,,periphery
+4530,Oryza sativa,Oryza sativa,,core
+4533,Oryza brachyantha,Oryza brachyantha,,periphery
+4536,Oryza nivara,Oryza nivara,,periphery
+4537,Oryza punctata,Oryza punctata,,periphery
+4538,Oryza glaberrima,Oryza glaberrima,,periphery
+4555,Setaria italica,Setaria italica,,core
+4558,Sorghum bicolor,Sorghum bicolor,,periphery
+4565,Triticum aestivum,Triticum aestivum,,periphery
+4572,Triticum urartu,Triticum urartu,,periphery
+4577,Zea mays,Zea mays,,core
+4641,Musa acuminata,Musa acuminata,,core
+4787,Phytophthora infestans,Phytophthora infestans,,core
+4792,Phytophthora parasitica,Phytophthora parasitica,,periphery
+4896,Schizosaccharomyces pombe,Schizosaccharomyces pombe,,core
+4897,Schizosaccharomyces japonicus,Schizosaccharomyces japonicus,,periphery
+4899,Schizosaccharomyces octosporus,Schizosaccharomyces octosporus,,core
+4909,Pichia kudriavzevii,Pichia kudriavzevii,,periphery
+4920,Millerozyma farinosa,Millerozyma farinosa,,periphery
+4922,Komagataella pastoris,Komagataella pastoris,,core
+4924,Scheffersomyces stipitis,Scheffersomyces stipitis,,core
+4929,Meyerozyma guilliermondii,Meyerozyma guilliermondii,,periphery
+4932,Saccharomyces cerevisiae,Saccharomyces cerevisiae,,core
+4950,Torulaspora delbrueckii,Torulaspora delbrueckii,,core
+4952,Yarrowia lipolytica,Yarrowia lipolytica,,core
+4956,Zygosaccharomyces rouxii,Zygosaccharomyces rouxii,,core
+4959,Debaryomyces hansenii,Debaryomyces hansenii,,periphery
+5011,Taphrina deformans,Taphrina deformans,,core
+5016,Bipolaris maydis,Bipolaris maydis,,periphery
+5017,Bipolaris zeicola,Bipolaris zeicola,,periphery
+5022,Leptosphaeria maculans,Leptosphaeria maculans,,core
+5037,Histoplasma capsulatum,Histoplasma capsulatum,,periphery
+5039,Blastomyces dermatitidis,Blastomyces dermatitidis,,periphery
+5057,Aspergillus clavatus,Aspergillus clavatus,,periphery
+5059,Aspergillus flavus,Aspergillus flavus,,periphery
+5061,Aspergillus niger,Aspergillus niger,,core
+5062,Aspergillus oryzae,Aspergillus oryzae,,periphery
+5111,Claviceps purpurea,Claviceps purpurea,,periphery
+5127,Fusarium fujikuroi,Fusarium fujikuroi,,periphery
+5141,Neurospora crassa,Neurospora crassa,,core
+5145,Podospora anserina,Podospora anserina,,periphery
+5147,Sordaria macrospora,Sordaria macrospora,,periphery
+5180,Sclerotinia sclerotiorum,Sclerotinia sclerotiorum,,periphery
+5207,Cryptococcus neoformans,Cryptococcus neoformans,,periphery
+5217,Tremella mesenterica,Tremella mesenterica,,core
+5270,Ustilago maydis,Ustilago maydis,,core
+5286,Rhodosporidium toruloides,Rhodosporidium toruloides,,core
+5297,Puccinia graminis,Puccinia graminis,,core
+5334,Schizophyllum commune,Schizophyllum commune,,periphery
+5341,Agaricus bisporus,Agaricus bisporus,,core
+5346,Coprinopsis cinerea,Coprinopsis cinerea,,core
+5465,Colletotrichum orbiculare,Colletotrichum orbiculare,,periphery
+5476,Candida albicans,Candida albicans,,core
+5478,Candida glabrata,Candida glabrata,,core
+5479,Candida maltosa,Candida maltosa,,periphery
+5480,Candida parapsilosis,Candida parapsilosis,,periphery
+5482,Candida tropicalis,Candida tropicalis,,periphery
+5501,Coccidioides immitis,Coccidioides immitis,,periphery
+5507,Fusarium oxysporum,Fusarium oxysporum,,periphery
+5518,Fusarium graminearum,Fusarium graminearum,,core
+5551,Trichophyton rubrum,Trichophyton rubrum,,periphery
+5664,Leishmania major,Leishmania major,,core
+5671,Leishmania infantum,Leishmania infantum,,periphery
+5679,Leishmania panamensis,Leishmania panamensis,,core
+5691,Trypanosoma brucei,Trypanosoma brucei,,periphery
+5693,Trypanosoma cruzi,Trypanosoma cruzi,,core
+5722,Trichomonas vaginalis,Trichomonas vaginalis,,core
+5741,Giardia intestinalis,Giardia intestinalis,,core
+5759,Entamoeba histolytica,Entamoeba histolytica,,core
+5762,Naegleria gruberi,Naegleria gruberi,,core
+5786,Dictyostelium purpureum,Dictyostelium purpureum,,periphery
+5808,Cryptosporidium muris,Cryptosporidium muris,,core
+5811,Toxoplasma gondii,Toxoplasma gondii,,core
+5821,Plasmodium berghei,Plasmodium berghei,,periphery
+5825,Plasmodium chabaudi,Plasmodium chabaudi,,core
+5827,Plasmodium cynomolgi,Plasmodium cynomolgi,,periphery
+5833,Plasmodium falciparum,Plasmodium falciparum,,core
+5850,Plasmodium knowlesi,Plasmodium knowlesi,,periphery
+5855,Plasmodium vivax,Plasmodium vivax,,periphery
+5860,Plasmodium vinckei,Plasmodium vinckei,,periphery
+5865,Babesia bovis,Babesia bovis,,periphery
+5872,Babesia equi,Babesia equi,,core
+5874,Theileria annulata,Theileria annulata,,periphery
+5875,Theileria parva,Theileria parva,,periphery
+5888,Paramecium tetraurelia,Paramecium tetraurelia,,core
+5911,Tetrahymena thermophila,Tetrahymena thermophila,,periphery
+5932,Ichthyophthirius multifiliis,Ichthyophthirius multifiliis,,core
+5970,Exophiala dermatitidis,Exophiala dermatitidis,,periphery
+6087,Hydra vulgaris,Hydra vulgaris,,core
+6183,Schistosoma mansoni,Schistosoma mansoni,,core
+6211,Echinococcus multilocularis,Echinococcus multilocularis,,periphery
+6238,Caenorhabditis briggsae,Caenorhabditis briggsae,,periphery
+6239,Caenorhabditis elegans,Caenorhabditis elegans,,core
+6326,Bursaphelenchus xylophilus,Bursaphelenchus xylophilus,,core
+6334,Trichinella spiralis,Trichinella spiralis,,core
+6412,Helobdella robusta,Helobdella robusta,,core
+6500,Aplysia californica,Aplysia californica,,periphery
+6669,Daphnia pulex,Daphnia pulex,,core
+7029,Acyrthosiphon pisum,Acyrthosiphon pisum,,periphery
+7070,Tribolium castaneum,Tribolium castaneum,,core
+7091,Bombyx mori,Bombyx mori,,periphery
+7159,Aedes aegypti,Aedes aegypti,,periphery
+7165,Anopheles gambiae,Anopheles gambiae,,core
+7176,Culex quinquefasciatus,Culex quinquefasciatus,,core
+7209,Loa loa,Loa loa,,core
+7213,Ceratitis capitata,Ceratitis capitata,,periphery
+7217,Drosophila ananassae,Drosophila ananassae,,periphery
+7220,Drosophila erecta,Drosophila erecta,,periphery
+7222,Drosophila grimshawi,Drosophila grimshawi,,periphery
+7227,Drosophila melanogaster,Drosophila melanogaster,,core
+7230,Drosophila mojavensis,Drosophila mojavensis,,periphery
+7234,Drosophila persimilis,Drosophila persimilis,,periphery
+7237,Drosophila pseudoobscura,Drosophila pseudoobscura,,periphery
+7244,Drosophila virilis,Drosophila virilis,,periphery
+7245,Drosophila yakuba,Drosophila yakuba,,periphery
+7260,Drosophila willistoni,Drosophila willistoni,,periphery
+7370,Musca domestica,Musca domestica,,core
+7425,Nasonia vitripennis,Nasonia vitripennis,,core
+7460,Apis mellifera,Apis mellifera,,core
+7668,Strongylocentrotus purpuratus,Strongylocentrotus purpuratus,,core
+7719,Ciona intestinalis,Ciona intestinalis,,core
+7739,Branchiostoma floridae,Branchiostoma floridae,,core
+7897,Latimeria chalumnae,Latimeria chalumnae,,core
+7918,Lepisosteus oculatus,Lepisosteus oculatus,,core
+7955,Danio rerio,Danio rerio,,core
+7994,Astyanax mexicanus,Astyanax mexicanus,,periphery
+8010,Esox lucius,Esox lucius,,core
+8049,Gadus morhua,Gadus morhua,,core
+8081,Poecilia reticulata,Poecilia reticulata,,periphery
+8083,Xiphophorus maculatus,Xiphophorus maculatus,,periphery
+8090,Oryzias latipes,Oryzias latipes,,core
+8128,Oreochromis niloticus,Oreochromis niloticus,,core
+8153,Haplochromis burtoni,Haplochromis burtoni,,periphery
+8364,Xenopus (Silurana) tropicalis,Xenopus tropicalis,,core
+8469,Chelonia mydas,Chelonia mydas,,periphery
+8479,Chrysemys picta,Chrysemys picta,,core
+8496,Alligator mississippiensis,Alligator mississippiensis,,periphery
+8932,Columba livia,Columba livia,,periphery
+9031,Gallus gallus,Gallus gallus,,core
+9258,Ornithorhynchus anatinus,Ornithorhynchus anatinus,,core
+9305,Sarcophilus harrisii,Sarcophilus harrisii,,periphery
+9315,Macropus eugenii,Macropus eugenii,,periphery
+9361,Dasypus novemcinctus,Dasypus novemcinctus,,periphery
+9365,Erinaceus europaeus,Erinaceus europaeus,,periphery
+9371,Echinops telfairi,Echinops telfairi,,periphery
+9402,Pteropus alecto,Pteropus alecto,,periphery
+9478,Tarsius syrichta,Tarsius syrichta,,periphery
+9483,Callithrix jacchus,Callithrix jacchus,,periphery
+9541,Macaca fascicularis,Macaca fascicularis,,periphery
+9544,Macaca mulatta,Macaca mulatta,,periphery
+9555,Papio anubis,Papio anubis,,periphery
+9593,Gorilla gorilla,Gorilla gorilla,,periphery
+9597,Pan paniscus,Pan paniscus,,periphery
+9598,Pan troglodytes,Pan troglodytes,,periphery
+9601,Pongo abelii,Pongo abelii,,periphery
+9606,Homo sapiens,Homo sapiens,,core
+9612,Canis lupus,Canis lupus,,periphery
+9646,Ailuropoda melanoleuca,Ailuropoda melanoleuca,,periphery
+9668,Mustela putorius,Mustela putorius,,periphery
+9685,Felis catus,Felis catus,,periphery
+9694,Panthera tigris,Panthera tigris,,periphery
+9707,Odobenus rosmarus,Odobenus rosmarus,,periphery
+9713,Leptonychotes weddellii,Leptonychotes weddellii,,periphery
+9733,Orcinus orca,Orcinus orca,,periphery
+9739,Tursiops truncatus,Tursiops truncatus,,periphery
+9767,Balaenoptera acutorostrata,Balaenoptera acutorostrata,,periphery
+9778,Trichechus manatus,Trichechus manatus,,periphery
+9785,Loxodonta africana,Loxodonta africana,,core
+9818,Orycteropus afer,Orycteropus afer,,periphery
+9823,Sus scrofa,Sus scrofa,,periphery
+9913,Bos taurus,Bos taurus,,core
+9940,Ovis aries,Ovis aries,,core
+9978,Ochotona princeps,Ochotona princeps,,periphery
+9986,Oryctolagus cuniculus,Oryctolagus cuniculus,,core
+10029,Cricetulus griseus,Cricetulus griseus,,periphery
+10036,Mesocricetus auratus,Mesocricetus auratus,,periphery
+10042,Peromyscus maniculatus,Peromyscus maniculatus,,periphery
+10090,Mus musculus,Mus musculus,,core
+10116,Rattus norvegicus,Rattus norvegicus,,core
+10141,Cavia porcellus,Cavia porcellus,,core
+10160,Octodon degus,Octodon degus,,periphery
+10181,Heterocephalus glaber,Heterocephalus glaber,,periphery
+10224,Saccoglossus kowalevskii,Saccoglossus kowalevskii,,core
+10228,Trichoplax adhaerens,Trichoplax adhaerens,,core
+12957,Atta cephalotes,Atta cephalotes,,periphery
+13035,Dactylococcopsis salina PCC8305,Dactylococcopsis salina,,core
+13037,Danaus plexippus,Danaus plexippus,,core
+13249,Rhodnius prolixus,Rhodnius prolixus,,periphery
+13333,Amborella trichopoda,Amborella trichopoda,,core
+13349,Arthrobotrys oligospora,Arthrobotrys oligospora,,periphery
+13616,Monodelphis domestica,Monodelphis domestica,,periphery
+13684,Parastagonospora nodorum,Parastagonospora nodorum,,periphery
+13689,Sphingomonas paucimobilis,Sphingomonas paucimobilis,,core
+13690,Sphingobium yanoikuyae,Sphingobium yanoikuyae,,periphery
+13735,Pelodiscus sinensis,Pelodiscus sinensis,,core
+15368,Brachypodium distachyon,Brachypodium distachyon,,periphery
+27288,Naumovozyma castellii,Naumovozyma castellii,,core
+27289,Naumovozyma dairenensis,Naumovozyma dairenensis,,periphery
+27337,Verticillium dahliae,Verticillium dahliae,,periphery
+27679,Saimiri boliviensis,Saimiri boliviensis,,periphery
+27923,Mnemiopsis leidyi,Mnemiopsis leidyi,,core
+28042,Saccharopolyspora rectivirgula,Saccharopolyspora rectivirgula,,core
+28072,Nostoc sp. PCC7524,Nostoc sp. PCC7524,,periphery
+28115,Porphyromonas macacae,Porphyromonas macacae,,periphery
+28152,Yersinia kristensenii,Yersinia kristensenii,,periphery
+28176,Candidatus Photodesmus katoptron,Photodesmus katoptron,,periphery
+28229,Colwellia psychrerythraea,Colwellia psychrerythraea,,core
+28258,Cobetia marina,Cobetia marina,,core
+28377,Anolis carolinensis,Anolis carolinensis,,core
+28444,Herbidospora cretacea,Herbidospora cretacea,,periphery
+28532,Tarenaya hassleriana,Tarenaya hassleriana,,periphery
+28564,Talaromyces stipitatus,Talaromyces stipitatus,,periphery
+28583,Allomyces macrogynus,Allomyces macrogynus,,core
+28737,Elephantulus edwardii,Elephantulus edwardii,,periphery
+28985,Kluyveromyces lactis,Kluyveromyces lactis,,core
+29073,Ursus maritimus,Ursus maritimus,,periphery
+29078,Eptesicus fuscus,Eptesicus fuscus,,periphery
+29176,Neospora caninum,Neospora caninum,,periphery
+29306,Streptomyces griseoluteus,Streptomyces griseoluteus,,periphery
+29486,Yersinia ruckeri,Yersinia ruckeri,,periphery
+29495,Vibrio navarrensis,Vibrio navarrensis,,periphery
+29540,Natrialba asiatica DSM12278,Natrialba asiatica,,periphery
+29581,Janthinobacterium lividum,Janthinobacterium lividum,,periphery
+29730,Gossypium raimondii,Gossypium raimondii,,periphery
+29760,Vitis vinifera,Vitis vinifera,,core
+29850,Gaeumannomyces graminis,Gaeumannomyces graminis,,periphery
+29875,Trichoderma virens,Trichoderma virens,,core
+29908,Sporothrix schenckii,Sporothrix schenckii,,periphery
+30611,Otolemur garnettii,Otolemur garnettii,,periphery
+31033,Takifugu rubripes,Takifugu rubripes,,periphery
+31234,Caenorhabditis remanei,Caenorhabditis remanei,,periphery
+31870,Colletotrichum graminicola,Colletotrichum graminicola,,periphery
+31954,Bifidobacterium pseudolongum subsp. pseudolongum,Bifidobacterium pseudolongum,,periphery
+31964,Clavibacter michiganensis subsp. sepedonicus,Clavibacter michiganensis sepedonicus,,core
+32024,Campylobacter sputorum biovar sputorum,Campylobacter sputorum,,periphery
+32042,Pseudomonas stutzeri ATCC14405,Pseudomonas stutzeri ATCC14405,,periphery
+32049,Synechococcus sp. PCC7002,Synechococcus sp. PCC7002,,core
+32051,Synechococcus sp. WH 7803,Synechococcus sp. WH 7803,,periphery
+32057,Calothrix sp. PCC7103,Calothrix sp. PCC7103,,periphery
+32264,Tetranychus urticae,Tetranychus urticae,,core
+32507,Neolamprologus brichardi,Neolamprologus brichardi,,periphery
+33035,Blautia producta,Blautia producta,,core
+33169,Eremothecium gossypii,Eremothecium gossypii,,core
+33178,Aspergillus terreus,Aspergillus terreus,,periphery
+33188,Uncinocarpus reesii,Uncinocarpus reesii,,periphery
+33876,Catenuloplanes japonicus,Catenuloplanes japonicus,,periphery
+33898,Streptomyces galbus,Streptomyces galbus,,periphery
+33905,Bifidobacterium thermophilum,Bifidobacterium thermophilum,,periphery
+34007,Paracoccus versutus,Paracoccus versutus,,core
+34349,Mixia osmundae,Mixia osmundae,,core
+34373,Blumeria graminis,Blumeria graminis,,periphery
+34506,Strongyloides ratti,Strongyloides ratti,,core
+34740,Heliconius melpomene,Heliconius melpomene,,periphery
+34839,Chinchilla lanigera,Chinchilla lanigera,,periphery
+35128,Thalassiosira pseudonana,Thalassiosira pseudonana,,core
+35703,Citrobacter amalonaticus,Citrobacter amalonaticus,,core
+35720,Thielavia terrestris,Thielavia terrestris,,periphery
+35725,Macrophomina phaseolina,Macrophomina phaseolina,,periphery
+35754,Dactylosporangium aurantiacum,Dactylosporangium aurantiacum,,periphery
+35760,Bifidobacterium choerinum,Bifidobacterium choerinum,,periphery
+35841,Bacillus thermoamylovorans,Bacillus thermoamylovorans,,periphery
+36033,Vanderwaltozyma polyspora,Vanderwaltozyma polyspora,,core
+36080,Mucor circinelloides,Mucor circinelloides,,periphery
+36331,Pythium irregulare,Pythium irregulare,,periphery
+36630,Neosartorya fischeri,Neosartorya fischeri,,core
+36651,Penicillium digitatum,Penicillium digitatum,,periphery
+36809,Mycobacterium abscessus,Mycobacterium abscessus,,core
+36870,Wigglesworthia glossinidia endosymbiont of Glossina brevipalpis,Wigglesworthia glossinidia sp. Gbr,,core
+36874,Porphyromonas cangingivalis,Porphyromonas cangingivalis,,periphery
+36875,Porphyromonas canoris,Porphyromonas canoris,,periphery
+36914,Lodderomyces elongisporus,Lodderomyces elongisporus,,periphery
+37659,Clostridium algidicarnis,Clostridium algidicarnis,,periphery
+37682,Aegilops tauschii,Aegilops tauschii,,periphery
+37692,Candidatus Phytoplasma mali,Phytoplasma mali,,core
+37727,Talaromyces marneffei,Talaromyces marneffei,,periphery
+37919,Rhodococcus opacus,Rhodococcus opacus,,core
+38033,Chaetomium globosum,Chaetomium globosum,,periphery
+38654,Alligator sinensis,Alligator sinensis,,periphery
+38727,Panicum virgatum,Panicum virgatum,,periphery
+38833,Micromonas pusilla,Micromonas pusilla,,periphery
+39416,Tuber melanosporum,Tuber melanosporum,,periphery
+40041,Streptococcus equi subsp. zooepidemicus,Streptococcus equi,,core
+40127,Neurospora tetrasperma,Neurospora tetrasperma,,periphery
+40148,Oryza glumipatula,Oryza glumipatula,,periphery
+40149,Oryza meridionalis,Oryza meridionalis,,periphery
+40215,Acinetobacter junii,Acinetobacter junii,,periphery
+40373,Acinetobacter sp. CIP-A165,Acinetobacter sp. CIPA165,,periphery
+40384,Aspergillus kawachii,Aspergillus kawachii,,periphery
+40483,Fomitopsis pinicola,Fomitopsis pinicola,,periphery
+40492,Stereum hirsutum,Stereum hirsutum,,core
+40559,Botrytis cinerea,Botrytis cinerea,,core
+40571,Lentzea albidocapillata,Lentzea albidocapillata,,periphery
+41431,Cyanothece sp. PCC8801,Cyanothece sp. PCC8801,,core
+41875,Bathycoccus prasinos,Bathycoccus prasinos,,periphery
+42068,Pneumocystis jirovecii,Pneumocystis jirovecii,,periphery
+42099,Pythium vexans,Pythium vexans,,periphery
+42254,Sorex araneus,Sorex araneus,,periphery
+42256,Rubrobacter radiotolerans,Rubrobacter radiotolerans,,periphery
+42345,Phoenix dactylifera,Phoenix dactylifera,,core
+42374,Candida dubliniensis,Candida dubliniensis,,core
+42565,Halomonas salina,Halomonas salina,,periphery
+43151,Anopheles darlingi,Anopheles darlingi,,periphery
+43179,Ictidomys tridecemlineatus,Ictidomys tridecemlineatus,,periphery
+43228,Capronia epimyces,Capronia epimyces,,periphery
+43229,Capronia coronata,Capronia coronata,,periphery
+43354,Prauserella rugosa,Prauserella rugosa,,periphery
+43759,Streptomyces wedmorensis,Streptomyces wedmorensis,,periphery
+43989,Cyanothece sp. ATCC51142,Cyanothece sp. ATCC51142,,core
+44056,Aureococcus anophagefferens,Aureococcus anophagefferens,,core
+44060,Streptomyces megasporus,Streptomyces megasporus,,periphery
+44251,Paenibacillus durus,Paenibacillus durus,,core
+44454,Mycobacterium avium subsp. avium,Mycobacterium avium avium,,core
+44689,Dictyostelium discoideum,Dictyostelium discoideum,,core
+45130,Bipolaris sorokiniana,Bipolaris sorokiniana,,periphery
+45151,Pyrenophora tritici-repentis,Pyrenophora triticirepentis,,periphery
+45157,Cyanidioschyzon merolae,Cyanidioschyzon merolae,,core
+45285,Eremothecium cymbalariae,Eremothecium cymbalariae,,periphery
+45351,Nematostella vectensis,Nematostella vectensis,,periphery
+45361,Mycoplasma conjunctivae,Mycoplasma conjunctivae,,periphery
+45596,Candida tenuis,Candida tenuis,,periphery
+46234,Anabaena sp. 90,Anabaena sp. 90,,periphery
+46256,Weissella hellenica,Weissella hellenica,,periphery
+46429,Sphingobium chlorophenolicum,Sphingobium chlorophenolicum,,core
+46681,Entamoeba dispar,Entamoeba dispar,,periphery
+47716,Streptomyces olivaceus,Streptomyces olivaceus,,periphery
+47763,Streptomyces lydicus,Streptomyces lydicus,,periphery
+47839,Mycobacterium triplex,Mycobacterium triplex,,periphery
+48698,Poecilia formosa,Poecilia formosa,,periphery
+50452,Arabis alpina,Arabis alpina,,periphery
+50960,Helicobacter trogontum,Helicobacter trogontum,,periphery
+51337,Jaculus jaculus,Jaculus jaculus,,periphery
+51453,Trichoderma reesei,Trichoderma reesei,,periphery
+51511,Ciona savignyi,Ciona savignyi,,periphery
+52598,Sulfitobacter sp. EE-36,Sulfitobacter sp. EE36,,core
+52644,Haliaeetus leucocephalus,Haliaeetus leucocephalus,,periphery
+53485,Pyrenophora teres,Pyrenophora teres,,periphery
+55207,Pectobacterium betavasculorum,Pectobacterium betavasculorum,,core
+55529,Guillardia theta,Guillardia theta,,core
+55601,Vibrio anguillarum,Vibrio anguillarum,,core
+55952,Streptomyces toyocaensis,Streptomyces toyocaensis,,periphery
+56107,Cylindrospermum stagnale PCC7417,Cylindrospermum stagnale,,periphery
+56110,Oscillatoria acuminata PCC6304,Oscillatoria acuminata,,periphery
+56780,Syntrophus aciditrophicus SB,Syntrophus aciditrophicus,,periphery
+57918,Fragaria vesca,Fragaria vesca,,core
+58123,Spirillospora albida,Spirillospora albida,,core
+58344,Streptomyces celluloflavus,Streptomyces celluloflavus,,periphery
+59196,Rickettsiella grylli,Rickettsiella grylli,,periphery
+59374,Fibrobacter succinogenes subsp. succinogenes S85,Fibrobacter succinogenes,,core
+59463,Myotis lucifugus,Myotis lucifugus,,periphery
+59538,Pantholops hodgsonii,Pantholops hodgsonii,,periphery
+59689,Arabidopsis lyrata,Arabidopsis lyrata,,periphery
+59748,Candidatus Phytoplasma australiense,Phytoplasma australiense,,periphery
+59894,Ficedula albicollis,Ficedula albicollis,,periphery
+59919,Prochlorococcus marinus subsp. pastoris str. CCMP1986,Prochlorococcus marinus pastoris,,periphery
+59921,Prochlorococcus marinus str. MIT 9107,Prochlorococcus marinus MIT9107,,periphery
+59925,Prochlorococcus marinus str. GP2,Prochlorococcus marinus GP2,,periphery
+59926,Prochlorococcus marinus str. SB,Prochlorococcus marinus SB,,periphery
+59931,Synechococcus sp. WH 7805,Synechococcus sp. WH 7805,,periphery
+60520,Lactobacillus paraplantarum,Lactobacillus paraplantarum,,periphery
+60711,Chlorocebus sabaeus,Chlorocebus sabaeus,,periphery
+61273,Ophiostoma piceae,Ophiostoma piceae,,periphery
+61459,Coniosporium apollinis,Coniosporium apollinis,,periphery
+61622,Rhinopithecus roxellana,Rhinopithecus roxellana,,periphery
+61647,Pluralibacter gergoviae,Pluralibacter gergoviae,,core
+61853,Nomascus leucogenys,Nomascus leucogenys,,periphery
+62928,Azoarcus sp. BH72,Azoarcus sp. BH72,,core
+62977,Acinetobacter sp. ADP1,Acinetobacter sp. ADP1,,core
+63400,Arthroderma benhamiae,Arthroderma benhamiae,,periphery
+63402,Microsporum gypseum,Microsporum gypseum,,periphery
+63405,Arthroderma otae,Arthroderma otae,,core
+63418,Trichophyton equinum,Trichophyton equinum,,periphery
+63577,Trichoderma atroviride,Trichoderma atroviride,,periphery
+63737,Nostoc punctiforme PCC73102,Nostoc punctiforme,,core
+64363,Mycosphaerella pini,Mycosphaerella pini,,periphery
+64471,Synechococcus sp. CC9311,Synechococcus sp. CC9311,,periphery
+65071,Pythium ultimum,Pythium ultimum,,core
+65093,Halothece sp. PCC7418,Halothece sp. PCC7418,,core
+65393,Cyanothece sp. PCC7424,Cyanothece sp. PCC7424,,periphery
+65489,Oryza barthii,Oryza barthii,,periphery
+65497,Actinoalloteichus cyanogriseus,Actinoalloteichus cyanogriseus,,periphery
+65672,Piriformospora indica,Piriformospora indica,,periphery
+66269,Pantoea stewartii,Pantoea stewartii,,core
+66373,Streptomyces niger,Streptomyces niger,,periphery
+66377,Streptomyces violens,Streptomyces violens,,periphery
+66429,Streptomyces roseoverticillatus,Streptomyces roseoverticillatus,,periphery
+66692,Bacillus clausii KSM-K16,Bacillus clausii,,periphery
+66869,Streptomyces atroolivaceus,Streptomyces atroolivaceus,,periphery
+66874,Streptomyces bicolor,Streptomyces bicolor,,periphery
+66875,Streptomyces catenulae,Streptomyces catenulae,,periphery
+66897,Streptomyces griseorubens,Streptomyces griseorubens,,periphery
+67257,Streptomyces albus subsp. albus,Streptomyces albus albus,,periphery
+67267,Streptomyces alboflavus,Streptomyces alboflavus,,periphery
+67275,Streptomyces aureocirculatus,Streptomyces aureocirculatus,,periphery
+67281,Streptomyces californicus,Streptomyces californicus,,periphery
+67315,Streptomyces lavenduligriseus,Streptomyces lavenduligriseus,,periphery
+67332,Streptomyces mutabilis,Streptomyces mutabilis,,periphery
+67352,Streptomyces purpeofuscus,Streptomyces purpeofuscus,,periphery
+67356,Streptomyces resistomycificus,Streptomyces resistomycificus,,periphery
+67373,Streptomyces varsoviensis,Streptomyces varsoviensis,,periphery
+67593,Phytophthora sojae,Phytophthora sojae,,periphery
+68170,Lechevalieria aerocolonigenes,Lechevalieria aerocolonigenes,,periphery
+68194,Streptomyces durhamensis,Streptomyces durhamensis,,periphery
+68199,Streptomyces flavochromogenes,Streptomyces flavochromogenes,,periphery
+68219,Streptomyces iakyrus,Streptomyces iakyrus,,periphery
+68223,Streptomyces katrae,Streptomyces katrae,,periphery
+68260,Streptomyces pyridomyceticus,Streptomyces pyridomyceticus,,periphery
+68570,Streptomyces albulus,Streptomyces albulus,,periphery
+68886,Theileria orientalis,Theileria orientalis,,periphery
+69014,Thermococcus kodakarensis KOD1,Thermococcus kodakarensis,,periphery
+69042,Synechococcus sp. WH 5701,Synechococcus sp. WH 5701,,periphery
+69279,Aquamicrobium defluvii,Aquamicrobium defluvii,,core
+69293,Gasterosteus aculeatus,Gasterosteus aculeatus,,core
+69319,Microplitis demolitor,Microplitis demolitor,,periphery
+69328,Pseudomonas sp. VLB120,Pseudomonas sp. VLB120,,periphery
+69395,Caulobacter henricii,Caulobacter henricii,,periphery
+69781,Penicillium oxalicum,Penicillium oxalicum,,periphery
+70448,Ostreococcus tauri,Ostreococcus tauri,,core
+70601,Pyrococcus horikoshii OT3,Pyrococcus horikoshii,,periphery
+71139,Eucalyptus grandis,Eucalyptus grandis,,core
+71421,Haemophilus influenzae Rd KW20,Haemophilus influenzae,,core
+72004,Bos mutus,Bos mutus,,periphery
+72019,Sphaeroforma arctica,Sphaeroforma arctica,,periphery
+72228,Ophiocordyceps sinensis,Ophiocordyceps sinensis,,periphery
+72558,Sporisorium reilianum,Sporisorium reilianum,,periphery
+72658,Boechera stricta,Boechera stricta,,periphery
+72664,Eutrema salsugineum,Eutrema salsugineum,,periphery
+73044,Streptomyces seoulensis,Streptomyces seoulensis,,periphery
+73501,Cordyceps militaris,Cordyceps militaris,,periphery
+74545,Prochlorococcus marinus str. MIT 9302,Prochlorococcus marinus MIT9302,,periphery
+74546,Prochlorococcus marinus str. MIT 9312,Prochlorococcus marinus MIT9312,,periphery
+74547,Prochlorococcus marinus str. MIT 9313,Prochlorococcus marinus MIT9313,,core
+75379,Thiomonas intermedia K12,Thiomonas intermedia,,core
+76114,Aromatoleum aromaticum EbN1,Aromatoleum aromaticum,,core
+76636,Mycetocola saprophilus,Mycetocola saprophilus,,periphery
+76869,Pseudomonas putida GB-1,Pseudomonas putida GB1,,periphery
+77586,Leersia perrieri,Leersia perrieri,,periphery
+77635,Bifidobacterium subtile,Bifidobacterium subtile,,periphery
+78245,Xanthobacter autotrophicus Py2,Xanthobacter autotrophicus,,core
+78344,Bifidobacterium gallinarum,Bifidobacterium gallinarum,,periphery
+78345,Bifidobacterium merycicum,Bifidobacterium merycicum,,periphery
+78346,Bifidobacterium ruminantium,Bifidobacterium ruminantium,,periphery
+78398,Pectobacterium carotovorum subsp. odoriferum,Pectobacterium carotovorum odoriferum,,periphery
+78579,Myceliophthora thermophila,Myceliophthora thermophila,,periphery
+78898,Mortierella verticillata,Mortierella verticillata,,core
+79684,Microtus ochrogaster,Microtus ochrogaster,,periphery
+80637,Coniophora puteana,Coniophora puteana,,periphery
+80884,Colletotrichum higginsianum,Colletotrichum higginsianum,,periphery
+81824,Monosiga brevicollis,Monosiga brevicollis,,core
+81985,Capsella rubella,Capsella rubella,,periphery
+82508,Trichosporon asahii,Trichosporon asahii,,core
+82654,Pseudanabaena sp. PCC7367,Pseudanabaena sp. PCC7367,,periphery
+82995,Serratia grimesii,Serratia grimesii,,core
+82996,Serratia plymuthica,Serratia plymuthica,,periphery
+83219,Sulfitobacter mediterraneus,Sulfitobacter mediterraneus,,core
+83332,Mycobacterium tuberculosis H37Rv,Mycobacterium tuberculosis H37Rv,,core
+83344,Pseudocercospora fijiensis,Pseudocercospora fijiensis,,periphery
+83406,gamma proteobacterium HdN1,Gammaproteobacteria bacterium HdN1,,periphery
+84531,Lysobacter antibioticus,Lysobacter antibioticus,,core
+84588,Synechococcus sp. WH 8102,Synechococcus sp. WH 8102,,periphery
+84751,Pseudozyma flocculosa,Pseudozyma flocculosa,,periphery
+85643,Thauera sp. MZ1T,Thauera sp. MZ1T,,core
+85681,Citrus clementina,Citrus clementina,,periphery
+85929,Sphaerulina musiva,Sphaerulina musiva,,periphery
+85962,Helicobacter pylori 26695,Helicobacter pylori 26695,,periphery
+85963,Helicobacter pylori J99,Helicobacter pylori J99,,periphery
+85982,Serpula lacrymans,Serpula lacrymans,,periphery
+86049,Cladophialophora carrionii,Cladophialophora carrionii,,periphery
+86106,endosymbiont of Acanthamoeba sp. UWC8,endosymbiont of Acanthamoeba,,core
+86416,Clostridium pasteurianum BC1,Clostridium pasteurianum BC1,,periphery
+87626,Pseudoalteromonas tunicata D2,Pseudoalteromonas tunicata,,core
+88036,Selaginella moellendorffii,Selaginella moellendorffii,,core
+89187,Roseovarius nubinhibens ISM,Roseovarius nubinhibens,,periphery
+89462,Bubalus bubalis,Bubalus bubalis,,periphery
+90371,Salmonella enterica subsp. enterica serovar Typhimurium,Salmonella enterica Typhimurium,,core
+90675,Camelina sativa,Camelina sativa,,periphery
+90813,Thiomicrospira sp. Milos-T1,Thiomicrospira sp. MilosT1,,core
+90814,Thiomicrospira sp. Milos-T2,Thiomicrospira sp. MilosT2,,periphery
+91464,Synechococcus sp. PCC7335,Synechococcus sp. PCC7335,,core
+91604,Candidatus Paracaedibacter acanthamoebae,Paracaedibacter acanthamoebae,,core
+92637,Metarhizium acridum,Metarhizium acridum,,periphery
+93057,Prochlorococcus marinus str. MIT 9201,Prochlorococcus marinus MIT9201,,periphery
+93059,Prochlorococcus marinus str. MIT 9211,Prochlorococcus marinus MIT9211,,periphery
+93060,Prochlorococcus marinus str. MIT 9215,Prochlorococcus marinus MIT9215,,periphery
+93220,Pandoraea pnomenusa,Pandoraea pnomenusa,,core
+93612,Setosphaeria turcica,Setosphaeria turcica,,periphery
+94122,Shewanella sp. ANA-3,Shewanella sp. ANA3,,periphery
+94624,Bordetella petrii,Bordetella petrii,,periphery
+95619,Pseudomonas sp. M1,Pseudomonas sp. M1,,periphery
+96561,Desulfococcus oleovorans Hxd3,Desulfococcus oleovorans,,core
+97096,Eutypa lata,Eutypa lata,,periphery
+97137,Lactobacillus sp. ASF360,Lactobacillus sp. ASF360,,periphery
+97138,Clostridium sp. ASF356,Clostridium sp. ASF356,,periphery
+97139,Clostridium sp. ASF502,Clostridium sp. ASF502,,periphery
+98439,Fischerella thermalis PCC7521,Fischerella thermalis,,periphery
+99158,Hammondia hammondi,Hammondia hammondi,,periphery
+99598,Calothrix sp. PCC7507,Calothrix sp. PCC7507,,periphery
+100226,Streptomyces coelicolor A3(2),Streptomyces coelicolor,,core
+100901,Wolbachia endosymbiont of Onchocerca ochengi,Wolbachia sp. Ooc,,periphery
+101028,Fusarium pseudograminearum,Fusarium pseudograminearum,,periphery
+101162,Bipolaris oryzae,Bipolaris oryzae,,core
+101510,Rhodococcus jostii RHA1,Rhodococcus jostii,,periphery
+101852,Glarea lozoyensis,Glarea lozoyensis,,periphery
+102107,Prunus mume,Prunus mume,,periphery
+102125,Xenococcus sp. PCC7305,Xenococcus sp. PCC7305,,periphery
+102129,Leptolyngbya sp. PCC7375,Leptolyngbya sp. PCC7375,,core
+102232,Gloeocapsa sp. PCC73106,Gloeocapsa sp. PCC73106,,periphery
+103372,Acromyrmex echinatior,Acromyrmex echinatior,,periphery
+103690,Nostoc sp. PCC7120,Nostoc sp. PCC7120,,periphery
+103733,Saccharothrix syringae,Saccharothrix syringae,,core
+104355,Gloeophyllum trabeum,Gloeophyllum trabeum,,core
+104623,Serratia sp. ATCC39006,Serratia sp. ATCC39006,,periphery
+105420,Streptacidiphilus neutrinimicus,Streptacidiphilus neutrinimicus,,core
+105422,Streptacidiphilus carbonis,Streptacidiphilus carbonis,,core
+105425,Streptacidiphilus albus,Streptacidiphilus albus,,core
+105559,Nitrosococcus watsonii C-113,Nitrosococcus watsonii,,periphery
+106370,Frankia sp. CcI3,Frankia sp. CcI3,,core
+106582,Maylandia zebra,Maylandia zebra,,periphery
+106648,Acinetobacter bereziniae,Acinetobacter bereziniae,,core
+107635,Methylosinus sp. LW3,Methylosinus sp. LW3,,core
+107636,Methylosinus sp. PW1,Methylosinus sp. PW1,,periphery
+107806,Buchnera aphidicola str. APS,Buchnera aphidicola APS,,core
+109478,Myotis brandtii,Myotis brandtii,,periphery
+109760,Spizellomyces punctatus,Spizellomyces punctatus,,core
+109871,Batrachochytrium dendrobatidis,Batrachochytrium dendrobatidis,,periphery
+110319,Nocardioides sp. CF8,Nocardioides sp. CF8,,periphery
+110365,Gregarina niphandrodes,Gregarina niphandrodes,,core
+110662,Synechococcus sp. CC9605,Synechococcus sp. CC9605,,periphery
+110663,Synechococcus sp. CC9616,Synechococcus sp. CC9616,,periphery
+111105,Porphyromonas gulae,Porphyromonas gulae,,core
+111780,Stanieria cyanosphaera PCC7437,Stanieria cyanosphaera,,core
+111781,Leptolyngbya sp. PCC7376,Leptolyngbya sp. PCC7376,,periphery
+112098,Saprolegnia diclina,Saprolegnia diclina,,periphery
+113355,Geminocystis herdmanii PCC6308,Geminocystis herdmanii,,core
+113395,Bradyrhizobium sp. Tv2a-2,Bradyrhizobium sp. Tv2a2,,periphery
+113608,Tetrapisispora phaffii,Tetrapisispora phaffii,,core
+114615,Bradyrhizobium sp. ORS 278,Bradyrhizobium sp. ORS278,,core
+115417,Pythium iwayamai,Pythium iwayamai,,core
+115711,Chlamydophila pneumoniae AR39,Chlamydophila pneumoniae AR39,,periphery
+115713,Chlamydophila pneumoniae CWL029,Chlamydophila pneumoniae CWL029,,core
+117187,Fusarium verticillioides,Fusarium verticillioides,,core
+118005,Chrysiogenes arsenatis DSM11915,Chrysiogenes arsenatis,,periphery
+118161,Pleurocapsa sp. PCC7319,Pleurocapsa sp. PCC7319,,core
+118163,Pleurocapsa sp. PCC7327,Pleurocapsa sp. PCC7327,,periphery
+118166,Nodosilinea nodulosa PCC7104,Nodosilinea nodulosa,,core
+118168,Coleofasciculus chthonoplastes PCC7420,Coleofasciculus chthonoplastes,,core
+118173,Pseudanabaena sp. PCC6802,Pseudanabaena sp. PCC6802,,core
+118797,Lipotes vexillifer,Lipotes vexillifer,,periphery
+120017,Ustilago hordei,Ustilago hordei,,core
+121225,Pediculus humanus,Pediculus humanus,,core
+121759,Paracoccidioides brasiliensis,Paracoccidioides brasiliensis,,periphery
+123214,Persephonella marina EX-H1,Persephonella marina,,core
+123899,Bordetella trematum,Bordetella trematum,,periphery
+126957,Strigamia maritima,Strigamia maritima,,core
+128390,Nipponia nippon,Nipponia nippon,,periphery
+130081,Galdieria sulphuraria,Galdieria sulphuraria,,periphery
+132113,Bombus impatiens,Bombus impatiens,,periphery
+132908,Pteropus vampyrus,Pteropus vampyrus,,periphery
+134676,Actinoplanes sp. SE50/110,Actinoplanes sp. SE50110,,core
+135651,Caenorhabditis brenneri,Caenorhabditis brenneri,,periphery
+136037,Zootermopsis nevadensis,Zootermopsis nevadensis,,core
+136273,Kocuria polaris,Kocuria polaris,,periphery
+136993,Methylosinus sp. LW4,Methylosinus sp. LW4,,periphery
+138119,Desulfitobacterium hafniense Y51,Desulfitobacterium hafniense,,core
+140110,Nectria haematococca,Nectria haematococca,,periphery
+140626,Lachnobacterium bovis,Lachnobacterium bovis,,core
+143224,Zobellia uliginosa,Zobellia uliginosa,,core
+144197,Stegastes partitus,Stegastes partitus,,periphery
+146891,Prochlorococcus marinus str. AS9601,Prochlorococcus marinus AS9601,,core
+146922,Streptomyces griseofuscus,Streptomyces griseofuscus,,periphery
+148304,Magnaporthiopsis poae,Magnaporthiopsis poae,,periphery
+148814,Lactobacillus kunkeei,Lactobacillus kunkeei,,core
+148960,Wallemia sebi,Wallemia sebi,,periphery
+153496,Kozakia baliensis,Kozakia baliensis,,periphery
+153721,Sporocytophaga myxococcoides,Sporocytophaga myxococcoides,,core
+153948,Nitrosomonas sp. AL212,Nitrosomonas sp. AL212,,periphery
+155515,Gallibacterium genomosp. 1,Gallibacterium genomosp.,,periphery
+155864,Escherichia coli O157:H7 str. EDL933,Escherichia coli O157H7,,periphery
+156578,Alteromonadales bacterium TW-7,Alteromonadales bacterium TW7,,core
+156889,Magnetococcus marinus MC-1,Magnetococcus marinus,,core
+156978,Corynebacterium imitans,Corynebacterium imitans,,periphery
+157072,Aphanomyces invadans,Aphanomyces invadans,,core
+157783,Pseudomonas cremoricolorata,Pseudomonas cremoricolorata,,periphery
+158189,Sphaerochaeta globosa str. Buddy,Sphaerochaeta globosa,,core
+158190,Sphaerochaeta pleomorpha str. Grapes,Sphaerochaeta pleomorpha,,periphery
+158500,Novosphingobium resinovorum,Novosphingobium resinovorum,,core
+158787,Bifidobacterium scardovii,Bifidobacterium scardovii,,periphery
+158822,Cedecea neteri,Cedecea neteri,,core
+159087,Dechloromonas aromatica RCB,Dechloromonas aromatica,,core
+159450,Burkholderia sacchari,Burkholderia sacchari,,periphery
+159749,Thalassiosira oceanica,Thalassiosira oceanica,,periphery
+160488,Pseudomonas putida KT2440,Pseudomonas putida KT2440,,core
+160492,Xylella fastidiosa 9a5c,Xylella fastidiosa 9a5c,,core
+160799,Paenibacillus borealis,Paenibacillus borealis,,core
+160860,Auricularia delicata,Auricularia delicata,,periphery
+161156,Thermodesulfobacterium hydrogeniphilum,Thermodesulfobacterium hydrogeniphilum,,core
+161528,Erythrobacter sp. SD-21,Erythrobacter sp. SD21,,core
+161934,Beta vulgaris,Beta vulgaris,,core
+162425,Aspergillus nidulans,Aspergillus nidulans,,core
+163164,Wolbachia endosymbiont of Drosophila melanogaster,Wolbachia sp. Dme,,core
+163908,Anabaena sp. PCC7108,Anabaena sp. PCC7108,,periphery
+164328,Phytophthora ramorum,Phytophthora ramorum,,core
+164757,Mycobacterium sp. JLS,Mycobacterium sp. JLS,,periphery
+166314,Synechococcus sp. WH 8109,Synechococcus sp. WH 8109,,periphery
+166318,Synechococcus sp. WH 8016,Synechococcus sp. WH 8016,,periphery
+167539,Prochlorococcus marinus subsp. marinus str. CCMP1375,Prochlorococcus marinus CCMP1375,,periphery
+167542,Prochlorococcus marinus str. MIT 9515,Prochlorococcus marinus MIT9515,,periphery
+167546,Prochlorococcus marinus str. MIT 9301,Prochlorococcus marinus MIT9301,,periphery
+167548,Prochlorococcus marinus str. MIT 9314,Prochlorococcus marinus MIT9314,,periphery
+167550,Prochlorococcus marinus str. MIT 9322,Prochlorococcus marinus MIT9322,,periphery
+167555,Prochlorococcus marinus str. NATL1A,Prochlorococcus marinus NATL1A,,periphery
+169963,Listeria monocytogenes EGD-e,Listeria monocytogenes EGDe,,core
+170187,Streptococcus pneumoniae TIGR4,Streptococcus pneumoniae TIGR4,,core
+171101,Streptococcus pneumoniae R6,Streptococcus pneumoniae R6,,core
+171693,Oceanobacillus picturae,Oceanobacillus picturae,,core
+172045,Elizabethkingia miricola,Elizabethkingia miricola,,core
+172088,Bradyrhizobium sp. th.b2,Bradyrhizobium sp. thb2,,periphery
+176090,Streptococcus sinensis,Streptococcus sinensis,,periphery
+176275,Beauveria bassiana,Beauveria bassiana,,periphery
+176279,Staphylococcus epidermidis RP62A,Staphylococcus epidermidis RP62A,,periphery
+176280,Staphylococcus epidermidis ATCC12228,Staphylococcus epidermidis ATCC12228,,periphery
+176299,Agrobacterium fabrum str. C58,Agrobacterium fabrum,,core
+176946,Python bivittatus,Python bivittatus,,periphery
+177416,Francisella tularensis subsp. tularensis SCHU S4,Francisella tularensis SCHUS4,,core
+177437,Desulfobacterium autotrophicum HRM2,Desulfobacterium autotrophicum,,core
+177439,Desulfotalea psychrophila LSv54,Desulfotalea psychrophila,,core
+178306,Pyrobaculum aerophilum str. IM2,Pyrobaculum aerophilum,,periphery
+178901,Acetobacter malorum,Acetobacter malorum,,periphery
+179408,Oscillatoria nigro-viridis PCC7112,Oscillatoria nigroviridis,,core
+180281,Cyanobium sp. PCC7001,Cyanobium sp. PCC7001,,core
+180332,Robinsoniella peoriensis,Robinsoniella peoriensis,,core
+181119,Pseudopodoces humilis,Pseudopodoces humilis,,periphery
+182082,Chlamydophila pneumoniae TW-183,Chlamydophila pneumoniae TW183,,periphery
+182217,Helicobacter cetorum MIT 00-7128,Helicobacter cetorum MIT007128,,periphery
+185453,Chrysochloris asiatica,Chrysochloris asiatica,,periphery
+186490,Candidatus Baumannia cicadellinicola,Baumannia cicadellinicola,,core
+186497,Pyrococcus furiosus DSM3638,Pyrococcus furiosus,,periphery
+187272,Alkalilimnicola ehrlichii MLHE-1,Alkalilimnicola ehrlichii,,core
+187303,Methylocystis sp. SC2,Methylocystis sp. SC2,,periphery
+188626,Dermacoccus sp. Ellin185,Dermacoccus sp. Ellin185,,periphery
+189425,Paenibacillus graminis,Paenibacillus graminis,,core
+189426,Paenibacillus odorifer,Paenibacillus odorifer,,core
+189753,Bradyrhizobium sp. Ec3.3,Bradyrhizobium sp. Ec33,,periphery
+190304,Fusobacterium nucleatum subsp. nucleatum ATCC25586,Fusobacterium nucleatum ATCC25586,,core
+190486,Xanthomonas axonopodis pv. citri str. 306,Xanthomonas axonopodis citri,,periphery
+190650,Caulobacter crescentus CB15,Caulobacter crescentus CB15,,core
+191610,Corynebacterium atypicum,Corynebacterium atypicum,,periphery
+192222,Campylobacter jejuni subsp. jejuni NCTC11168,Campylobacter jejuni NCTC11168,,core
+192875,Capsaspora owczarzaki,Capsaspora owczarzaki,,core
+192952,Methanosarcina mazei Go1,Methanosarcina mazei,,periphery
+194439,Chlorobium tepidum TLS,Chlorobium tepidum,,core
+194867,Sphingomonas sp. ATCC31555,Sphingomonas sp. ATCC31555,,periphery
+195103,Clostridium perfringens ATCC13124,Clostridium perfringens ATCC13124,,core
+195105,Haematobacter massiliensis,Haematobacter massiliensis,,core
+195250,Synechococcus sp. PCC7336,Synechococcus sp. PCC7336,,periphery
+195253,Synechococcus sp. PCC6312,Synechococcus sp. PCC6312,,periphery
+195522,Thermococcus nautili,Thermococcus nautili,,core
+196162,Nocardioides sp. JS614,Nocardioides sp. JS614,,periphery
+196164,Corynebacterium efficiens YS-314,Corynebacterium efficiens,,periphery
+196367,Burkholderia sordidicola,Burkholderia sordidicola,,periphery
+196490,Bradyrhizobium sp. Ai1a-2,Bradyrhizobium sp. Ai1a2,,periphery
+196627,Corynebacterium glutamicum ATCC13032,Corynebacterium glutamicum,,periphery
+197221,Thermosynechococcus elongatus BP-1,Thermosynechococcus elongatus,,core
+198094,Bacillus anthracis str. Ames,Bacillus anthracis Ames,,periphery
+198214,Shigella flexneri 2a str. 301,Shigella flexneri,,core
+198467,Anoxybacillus gonensis,Anoxybacillus gonensis,,core
+198628,Dickeya dadantii 3937,Dickeya dadantii 3937,,core
+198804,Buchnera aphidicola str. Sg,Buchnera aphidicola Sg,,periphery
+199306,Coccidioides posadasii,Coccidioides posadasii,,core
+199310,Escherichia coli CFT073,Escherichia coli CFT073,,core
+202698,Punctularia strigosozonata,Punctularia strigosozonata,,periphery
+202752,Listeria ivanovii subsp. londoniensis,Listeria ivanovii londoniensis,,periphery
+202952,Acinetobacter gerneri,Acinetobacter gerneri,,periphery
+202954,Acinetobacter tandoii,Acinetobacter tandoii,,periphery
+202955,Acinetobacter tjernbergiae,Acinetobacter tjernbergiae,,periphery
+202956,Acinetobacter towneri,Acinetobacter towneri,,periphery
+203119,Ruminiclostridium thermocellum ATCC27405,Ruminiclostridium thermocellum,,core
+203120,Leuconostoc mesenteroides subsp. mesenteroides ATCC8293,Leuconostoc mesenteroides,,periphery
+203122,Saccharophagus degradans 2-40,Saccharophagus degradans,,core
+203123,Oenococcus oeni PSU-1,Oenococcus oeni,,periphery
+203124,Trichodesmium erythraeum IMS101,Trichodesmium erythraeum,,core
+203267,Tropheryma whipplei str. Twist,Tropheryma whipplei,,core
+203275,Tannerella forsythia ATCC43037,Tannerella forsythia,,core
+203907,Candidatus Blochmannia floridanus,Blochmannia floridanus,,periphery
+203908,Melampsora larici-populina,Melampsora laricipopulina,,periphery
+204536,Sulfurihydrogenibium azorense Az-Fu1,Sulfurihydrogenibium azorense,,core
+204669,Candidatus Koribacter versatilis Ellin345,Koribacter versatilis,,core
+204773,Herminiimonas arsenicoxydans,Herminiimonas arsenicoxydans,,core
+205914,Haemophilus somnus 129PT,Haemophilus somnus,,periphery
+205918,Pseudomonas syringae pv. syringae B728a,Pseudomonas syringae B728a,,periphery
+205920,Ehrlichia chaffeensis str. Arkansas,Ehrlichia chaffeensis,,periphery
+205922,Pseudomonas fluorescens Pf0-1,Pseudomonas fluorescens Pf01,,periphery
+207559,Desulfovibrio alaskensis G20,Desulfovibrio alaskensis,,periphery
+207954,Neptuniibacter caesariensis,Neptuniibacter caesariensis,,core
+208439,Amycolatopsis japonica,Amycolatopsis japonica,,periphery
+208444,Amycolatopsis vancoresmycina,Amycolatopsis vancoresmycina,,periphery
+208596,Carnobacterium sp. 17-4,Carnobacterium sp. 174,,core
+208960,Fomitiporia mediterranea,Fomitiporia mediterranea,,periphery
+209285,Chaetomium thermophilum,Chaetomium thermophilum,,periphery
+210007,Streptococcus mutans UA159,Streptococcus mutans UA159,,periphery
+211110,Streptococcus agalactiae NEM316,Streptococcus agalactiae NEM316,,periphery
+211114,Allokutzneria albata,Allokutzneria albata,,periphery
+211165,Chlorogloeopsis fritschii PCC6912,Chlorogloeopsis fritschii,,core
+211586,Shewanella oneidensis MR-1,Shewanella oneidensis,,core
+212042,Anaplasma phagocytophilum str. HZ,Anaplasma phagocytophilum,,core
+214092,Yersinia pestis CO92,Yersinia pestis CO92,,core
+215358,Larimichthys crocea,Larimichthys crocea,,periphery
+215803,Enhygromyxa salina,Enhygromyxa salina,,periphery
+216142,Pseudomonas rhizosphaerae,Pseudomonas rhizosphaerae,,periphery
+216432,Croceibacter atlanticus HTCC2559,Croceibacter atlanticus,,core
+216591,Burkholderia cenocepacia J2315,Burkholderia cenocepacia,,core
+216594,Mycobacterium marinum M,Mycobacterium marinum,,periphery
+216595,Pseudomonas fluorescens SBW25,Pseudomonas fluorescens SBW25,,periphery
+216596,Rhizobium leguminosarum bv. viciae 3841,Rhizobium leguminosarum 3841,,core
+216816,Bifidobacterium longum,Bifidobacterium longum,,core
+218140,Bifidobacterium psychraerophilum,Bifidobacterium psychraerophilum,,periphery
+218284,Bacillus vietnamensis,Bacillus vietnamensis,,periphery
+218491,Pectobacterium atrosepticum SCRI1043,Pectobacterium atrosepticum,,core
+218493,Salmonella bongori NCTC 12419,Salmonella bongori NCTC12419,,periphery
+218495,Streptococcus uberis 0140J,Streptococcus uberis,,periphery
+218497,Chlamydophila abortus S26/3,Chlamydophila abortus,,periphery
+218851,Aquilegia coerulea,Aquilegia coerulea,,periphery
+219305,Micromonospora sp. ATCC39149,Micromonospora sp. ATCC39149,,core
+220341,Salmonella enterica subsp. enterica serovar Typhi str. CT18,Salmonella enterica CT18,,core
+220664,Pseudomonas protegens Pf-5,Pseudomonas protegens Pf5,,periphery
+220668,Lactobacillus plantarum WCFS1,Lactobacillus plantarum,,periphery
+221027,Treponema putidum,Treponema putidum,,periphery
+221103,Moniliophthora roreri,Moniliophthora roreri,,periphery
+221109,Oceanobacillus iheyensis HTE831,Oceanobacillus iheyensis,,core
+221288,Mastigocladopsis repens PCC10914,Mastigocladopsis repens,,periphery
+221359,Synechococcus sp. RS9916,Synechococcus sp. RS9916,,periphery
+221360,Synechococcus sp. RS9917,Synechococcus sp. RS9917,,periphery
+221988,Mannheimia succiniciproducens MBEL55E,Mannheimia succiniciproducens,,core
+222534,Frankia sp. BMG5.12,Frankia sp. BMG512,,periphery
+222891,Neorickettsia sennetsu str. Miyayama,Neorickettsia sennetsu,,periphery
+222984,Natrinema altunense,Natrinema altunense,,periphery
+223184,Kocuria marina,Kocuria marina,,core
+223192,Togninia minima,Togninia minima,,periphery
+223283,Pseudomonas syringae pv. tomato str. DC3000,Pseudomonas syringae tomato,,core
+223926,Vibrio parahaemolyticus RIMD 2210633,Vibrio parahaemolyticus,,periphery
+224308,Bacillus subtilis subsp. subtilis str. 168,Bacillus subtilis,,core
+224324,Aquifex aeolicus VF5,Aquifex aeolicus,,core
+224325,Archaeoglobus fulgidus DSM4304,Archaeoglobus fulgidus,,core
+224719,Methanobrevibacter sp. AbM4,Methanobrevibacter sp. AbM4,,periphery
+224911,Bradyrhizobium diazoefficiens USDA 110,Bradyrhizobium diazoefficiens,,periphery
+224914,Brucella melitensis bv. 1 str. 16M,Brucella melitensis,,core
+224915,Buchnera aphidicola str. Bp,Buchnera aphidicola Bp,,periphery
+225117,Pyrus x bretschneideri,Pyrus x bretschneideri,,periphery
+225400,Myotis davidii,Myotis davidii,,periphery
+225849,Shewanella piezotolerans WP3,Shewanella piezotolerans,,core
+225937,Marinobacter adhaerens HP15,Marinobacter adhaerens,,periphery
+226185,Enterococcus faecalis V583,Enterococcus faecalis V583,,core
+226186,Bacteroides thetaiotaomicron VPI-5482,Bacteroides thetaiotaomicron,,core
+226899,Grosmannia clavigera,Grosmannia clavigera,,periphery
+227086,Bigelowiella natans,Bigelowiella natans,,core
+227377,Coxiella burnetii RSA 493,Coxiella burnetii,,core
+227882,Streptomyces avermitilis MA-4680,Streptomyces avermitilis,,periphery
+227941,Chlamydophila caviae GPIC,Chlamydophila caviae,,core
+228399,Actinobacillus pleuropneumoniae serovar 1 str. 4074,Actinobacillus pleuropneumoniae 1 4074,,core
+228405,Hyphomonas neptunium ATCC15444,Hyphomonas neptunium,,core
+228410,Nitrosomonas europaea ATCC19718,Nitrosomonas europaea,,periphery
+231434,Beijerinckia mobilis,Beijerinckia mobilis,,periphery
+232346,Halomonas alkaliantarctica,Halomonas alkaliantarctica,,core
+232348,Synechococcus sp. CB0101,Synechococcus sp. CB0101,,periphery
+232721,Acidovorax sp. JS42,Acidovorax sp. JS42,,core
+233412,Haemophilus ducreyi 35000HP,Haemophilus ducreyi,,periphery
+234267,Candidatus Solibacter usitatus Ellin6076,Solibacter usitatus,,core
+234621,Rhodococcus erythropolis PR4,Rhodococcus erythropolis,,periphery
+234826,Anaplasma marginale str. St. Maries,Anaplasma marginale Maries,,periphery
+234831,Pseudoalteromonas sp. SM9913,Pseudoalteromonas sp. SM9913,,core
+235279,Helicobacter hepaticus ATCC51449,Helicobacter hepaticus,,periphery
+235909,Geobacillus kaustophilus HTA426,Geobacillus kaustophilus,,core
+235985,Streptacidiphilus jiangxiensis,Streptacidiphilus jiangxiensis,,core
+236097,Alcanivorax sp. DG881,Alcanivorax sp. DG881,,core
+236814,Chryseobacterium formosense,Chryseobacterium formosense,,periphery
+237368,Candidatus Scalindua brodae,Scalindua brodae,,core
+237609,Pseudomonas alkylphenolia,Pseudomonas alkylphenolia,,periphery
+237727,Erythrobacter sp. NAP1,Erythrobacter sp. NAP1,,periphery
+240015,Acidobacterium capsulatum ATCC51196,Acidobacterium capsulatum,,core
+240016,Verrucomicrobium spinosum DSM4136,Verrucomicrobium spinosum,,core
+240292,Anabaena variabilis ATCC29413,Anabaena variabilis,,core
+240302,Halobacillus dabanensis,Halobacillus dabanensis,,core
+242159,Ostreococcus 'lucimarinus',Ostreococcus lucimarinus,,core
+242619,Porphyromonas gingivalis W83,Porphyromonas gingivalis W83,,core
+243090,Rhodopirellula baltica SH 1,Rhodopirellula baltica,,core
+243159,Acidithiobacillus ferrooxidans ATCC23270,Acidithiobacillus ferrooxidans ATCC23270,,core
+243160,Burkholderia mallei ATCC23344,Burkholderia mallei,,periphery
+243161,Chlamydia muridarum str. Nigg,Chlamydia muridarum,,periphery
+243164,Dehalococcoides mccartyi 195,Dehalococcoides mccartyi 195,,core
+243230,Deinococcus radiodurans R1,Deinococcus radiodurans,,core
+243231,Geobacter sulfurreducens PCA,Geobacter sulfurreducens,,core
+243232,Methanocaldococcus jannaschii DSM2661,Methanocaldococcus jannaschii,,core
+243233,Methylococcus capsulatus str. Bath,Methylococcus capsulatus,,core
+243265,Photorhabdus luminescens subsp. laumondii TTO1,Photorhabdus luminescens,,periphery
+243272,Mycoplasma arthritidis 158L3-1,Mycoplasma arthritidis,,periphery
+243273,Mycoplasma genitalium G37,Mycoplasma genitalium,,periphery
+243274,Thermotoga maritima MSB8,Thermotoga maritima,,core
+243275,Treponema denticola ATCC35405,Treponema denticola,,core
+243276,Treponema pallidum subsp. pallidum str. Nichols,Treponema pallidum,,core
+243277,Vibrio cholerae O1 biovar El Tor str. N16961,Vibrio cholerae O1,,core
+243365,Chromobacterium violaceum ATCC12472,Chromobacterium violaceum,,core
+243924,Pseudomonas lutea,Pseudomonas lutea,,periphery
+244447,Cynoglossus semilaevis,Cynoglossus semilaevis,,periphery
+244581,Candidatus Caedibacter acanthamoebae,Caedibacter acanthamoebae,,periphery
+244582,Candidatus Paracaedibacter symbiosus,Paracaedibacter symbiosus,,periphery
+245174,Wallemia ichthyophaga,Wallemia ichthyophaga,,core
+246194,Carboxydothermus hydrogenoformans Z-2901,Carboxydothermus hydrogenoformans,,core
+246195,Dichelobacter nodosus VCS1703A,Dichelobacter nodosus,,core
+246196,Mycobacterium smegmatis str. MC2 155,Mycobacterium smegmatis MC2155,,periphery
+246197,Myxococcus xanthus DK 1622,Myxococcus xanthus,,periphery
+246199,Ruminococcus albus 8,Ruminococcus albus 8,,core
+246200,Ruegeria pomeroyi DSS-3,Ruegeria pomeroyi,,periphery
+246201,Streptococcus mitis NCTC 12261,Streptococcus mitis NCTC 12261,,core
+246437,Tupaia chinensis,Tupaia chinensis,,periphery
+246969,Thermococcus sp. AM4,Thermococcus sp. AM4,,periphery
+247156,Nocardia farcinica IFM 10152,Nocardia farcinica,,periphery
+247490,planctomycete KSU-1,planctomycete KSU1,,core
+247633,marine gamma proteobacterium HTCC2143,Gammaproteobacteria bacterium HTCC2143,,core
+247634,marine gamma proteobacterium HTCC2148,Gammaproteobacteria bacterium HTCC2148,,core
+247639,marine gamma proteobacterium HTCC2080,Gammaproteobacteria bacterium HTCC2080,,periphery
+248742,Coccomyxa subellipsoidea,Coccomyxa subellipsoidea,,periphery
+251221,Gloeobacter violaceus PCC7421,Gloeobacter violaceus,,core
+251229,Chroococcidiopsis thermalis PCC7203,Chroococcidiopsis thermalis,,periphery
+252305,Oceanicola batsensis HTCC2597,Oceanicola batsensis,,core
+253839,Streptomyces sp. C,Streptomyces sp. C,,periphery
+254945,Ehrlichia ruminantium str. Welgevonden,Ehrlichia ruminantium,,periphery
+255470,Dehalococcoides mccartyi CBDB1,Dehalococcoides mccartyi CBDB1,,periphery
+257310,Bordetella bronchiseptica RB50,Bordetella bronchiseptica,,core
+257313,Bordetella pertussis Tohama I,Bordetella pertussis Tohama,,periphery
+257314,Lactobacillus johnsonii NCC 533,Lactobacillus johnsonii,,periphery
+257363,Rickettsia typhi str. Wilmington,Rickettsia typhi,,periphery
+258052,Kitasatospora arboriphila,Kitasatospora arboriphila,,core
+258533,Mycobacterium cosmeticum,Mycobacterium cosmeticum,,periphery
+258594,Rhodopseudomonas palustris CGA009,Rhodopseudomonas palustris CGA009,,core
+259536,Psychrobacter arcticus 273-4,Psychrobacter arcticus,,core
+260799,Bacillus anthracis str. Sterne,Bacillus anthracis Sterne,,periphery
+261292,Nitrosomonas sp. Is79A3,Nitrosomonas sp. Is79A3,,periphery
+261317,Buchnera aphidicola str. Ctu,Buchnera aphidicola Ctu,,core
+262316,Mycobacterium avium subsp. paratuberculosis K-10,Mycobacterium avium paratuberculosis,,periphery
+262543,Exiguobacterium sibiricum 255-15,Exiguobacterium sibiricum,,periphery
+262719,Mycoplasma hyopneumoniae J,Mycoplasma hyopneumoniae J,,core
+262723,Mycoplasma synoviae 53,Mycoplasma synoviae,,periphery
+262724,Thermus thermophilus HB27,Thermus thermophilus HB27,,core
+262768,Onion yellows phytoplasma OY-M,Phytoplasma onion yellows,,periphery
+263358,Verrucosispora maris AB-18-032,Verrucosispora maris,,core
+263815,Pneumocystis murina,Pneumocystis murina,,core
+263820,Picrophilus torridus DSM9790,Picrophilus torridus,,core
+264198,Ralstonia eutropha JMP134,Ralstonia eutropha JMP134,,periphery
+264199,Streptococcus thermophilus LMG 18311,Streptococcus thermophilus LMG18311,,periphery
+264201,Candidatus Protochlamydia amoebophila UWE25,Protochlamydia amoebophila,,core
+264202,Chlamydophila felis Fe/C-56,Chlamydophila felis,,periphery
+264203,Zymomonas mobilis subsp. mobilis ZM4,Zymomonas mobilis ZM4,,periphery
+264402,Capsella grandiflora,Capsella grandiflora,,periphery
+264462,Bdellovibrio bacteriovorus HD100,Bdellovibrio bacteriovorus HD100,,core
+264730,Pseudomonas syringae pv. phaseolicola 1448A,Pseudomonas syringae phaseolicola,,core
+264731,Prevotella ruminicola 23,Prevotella ruminicola,,core
+264732,Moorella thermoacetica ATCC39073,Moorella thermoacetica,,core
+264951,Byssochlamys spectabilis,Byssochlamys spectabilis,,periphery
+265072,Methylobacillus flagellatus KT,Methylobacillus flagellatus,,core
+265311,Mesoplasma florum L1,Mesoplasma florum,,core
+265729,Bacillus cibi,Bacillus cibi,,periphery
+266117,Rubrobacter xylanophilus DSM9941,Rubrobacter xylanophilus,,core
+266264,Cupriavidus metallidurans CH34,Cupriavidus metallidurans,,periphery
+266265,Burkholderia xenovorans LB400,Burkholderia xenovorans,,periphery
+266748,Chryseobacterium antarcticum,Chryseobacterium antarcticum,,periphery
+266762,Porphyromonas gingivicanis,Porphyromonas gingivicanis,,periphery
+266779,Chelativorans sp. BNC1,Chelativorans sp. BNC1,,core
+266809,Thalassobacter stenotrophicus,Thalassobacter stenotrophicus,,core
+266834,Sinorhizobium meliloti 1021,Sinorhizobium meliloti,,core
+266835,Mesorhizobium loti MAFF303099,Mesorhizobium loti MAFF303099,,core
+266940,Kineococcus radiotolerans SRS30216,Kineococcus radiotolerans,,core
+267377,Methanococcus maripaludis S2,Methanococcus maripaludis S2,,periphery
+267608,Ralstonia solanacearum GMI1000,Ralstonia solanacearum GMI1000,,core
+267747,Propionibacterium acnes KPA171202,Propionibacterium acnes KPA171202,,core
+267748,Mycoplasma mobile 163K,Mycoplasma mobile,,periphery
+268407,Paenibacillus wynnii,Paenibacillus wynnii,,periphery
+268739,Natronomonas moolapensis 8.8.11,Natronomonas moolapensis,,periphery
+269084,Synechococcus elongatus PCC6301,Synechococcus elongatus PCC6301,,core
+269482,Burkholderia vietnamiensis G4,Burkholderia vietnamiensis,,periphery
+269484,Ehrlichia canis str. Jake,Ehrlichia canis,,periphery
+269796,Rhodospirillum rubrum ATCC11170,Rhodospirillum rubrum,,core
+269797,Methanosarcina barkeri str. Fusaro,Methanosarcina barkeri,,core
+269798,Cytophaga hutchinsonii ATCC33406,Cytophaga hutchinsonii,,core
+269799,Geobacter metallireducens GS-15,Geobacter metallireducens,,core
+269800,Thermobifida fusca YX,Thermobifida fusca,,core
+270374,Marinobacter sp. ELB17,Marinobacter sp. ELB17,,periphery
+272123,Anabaena cylindrica PCC7122,Anabaena cylindrica,,periphery
+272134,Leptolyngbya boryana PCC6306,Leptolyngbya boryana,,periphery
+272556,Aggregatibacter actinomycetemcomitans HK1651,Aggregatibacter actinomycetemcomitans HK1651,,periphery
+272557,Aeropyrum pernix K1,Aeropyrum pernix,,core
+272558,Bacillus halodurans C-125,Bacillus halodurans,,periphery
+272559,Bacteroides fragilis NCTC 9343,Bacteroides fragilis NCTC 9343,,core
+272560,Burkholderia pseudomallei K96243,Burkholderia pseudomallei K96243,,core
+272562,Clostridium acetobutylicum ATCC824,Clostridium acetobutylicum,,core
+272563,Peptoclostridium difficile 630,Peptoclostridium difficile 630,,core
+272568,Gluconacetobacter diazotrophicus PA1 5,Gluconacetobacter diazotrophicus,,core
+272569,Haloarcula marismortui ATCC43049,Haloarcula marismortui,,periphery
+272621,Lactobacillus acidophilus NCFM,Lactobacillus acidophilus NCFM,,periphery
+272623,Lactococcus lactis subsp. lactis Il1403,Lactococcus lactis Il1403,,core
+272624,Legionella pneumophila subsp. pneumophila str. Philadelphia 1,Legionella pneumophila Philadelphia,,core
+272626,Listeria innocua Clip11262,Listeria innocua,,core
+272630,Methylobacterium extorquens AM1,Methylobacterium extorquens AM1,,core
+272631,Mycobacterium leprae TN,Mycobacterium leprae,,periphery
+272632,Mycoplasma mycoides subsp. mycoides SC str. PG1,Mycoplasma mycoides,,periphery
+272633,Mycoplasma penetrans HF-2,Mycoplasma penetrans,,periphery
+272635,Mycoplasma pulmonis UAB CTIP,Mycoplasma pulmonis,,periphery
+272844,Pyrococcus abyssi GE5,Pyrococcus abyssi,,core
+272942,Rhodobacter capsulatus SB 1003,Rhodobacter capsulatus,,periphery
+272943,Rhodobacter sphaeroides 2.4.1,Rhodobacter sphaeroides 241,,periphery
+272947,Rickettsia prowazekii str. Madrid E,Rickettsia prowazekii,,periphery
+272951,Rickettsia sibirica 246,Rickettsia sibirica,,core
+272952,Hyaloperonospora arabidopsidis,Hyaloperonospora arabidopsidis,,core
+273057,Sulfolobus solfataricus P2,Sulfolobus solfataricus,,core
+273063,Sulfolobus tokodaii str. 7,Sulfolobus tokodaii,,periphery
+273068,Caldanaerobacter subterraneus subsp. tengcongensis MB4,Caldanaerobacter subterraneus,,core
+273075,Thermoplasma acidophilum DSM1728,Thermoplasma acidophilum,,periphery
+273116,Thermoplasma volcanium GSS1,Thermoplasma volcanium,,core
+273119,Ureaplasma parvum serovar 3 str. ATCC700970,Ureaplasma parvum,,core
+273121,Wolinella succinogenes DSM1740,Wolinella succinogenes,,core
+273371,Candida orthopsilosis,Candida orthopsilosis,,periphery
+273526,Serratia marcescens subsp. marcescens Db11,Serratia marcescens Db11,,core
+273677,Microbacterium oleivorans,Microbacterium oleivorans,,periphery
+278197,Pediococcus pentosaceus ATCC25745,Pediococcus pentosaceus,,periphery
+278957,Diplosphaera colitermitum TAV2,Diplosphaera colitermitum,,periphery
+278963,Acidobacteriaceae bacterium TAA166,Acidobacteriaceae bacterium TAA166,,core
+279010,Bacillus licheniformis DSM13,Bacillus licheniformis,,core
+279238,Novosphingobium aromaticivorans DSM12444,Novosphingobium aromaticivorans,,periphery
+279714,Pseudogulbenkiania ferrooxidans 2002,Pseudogulbenkiania ferrooxidans,,core
+279808,Staphylococcus haemolyticus JCSC1435,Staphylococcus haemolyticus,,periphery
+281090,Leifsonia xyli subsp. xyli str. CTCB07,Leifsonia xyli CTCB07,,core
+281687,Caenorhabditis japonica,Caenorhabditis japonica,,periphery
+283165,Bartonella quintana str. Toulouse,Bartonella quintana,,periphery
+283166,Bartonella henselae str. Houston-1,Bartonella henselae,,core
+283699,Pseudoalteromonas sp. Bsw20308,Pseudoalteromonas sp. Bsw20308,,core
+283942,Idiomarina loihiensis L2TR,Idiomarina loihiensis,,core
+284031,Streptomyces flavovariabilis,Streptomyces flavovariabilis,,periphery
+285514,Streptomyces xylophagus,Streptomyces xylophagus,,periphery
+285535,Streptomyces fulvoviolaceus,Streptomyces fulvoviolaceus,,periphery
+287986,Amycolatopsis rifamycinica,Amycolatopsis rifamycinica,,periphery
+288000,Bradyrhizobium sp. BTAi1,Bradyrhizobium sp. BTAi1,,periphery
+288705,Renibacterium salmoninarum ATCC33209,Renibacterium salmoninarum,,core
+289376,Thermodesulfovibrio yellowstonii DSM11347,Thermodesulfovibrio yellowstonii,,core
+289377,Thermodesulfobacterium commune DSM2178,Thermodesulfobacterium commune,,periphery
+289397,Mycoplasma bovis PG45,Mycoplasma bovis,,periphery
+290315,Chlorobium limicola DSM245,Chlorobium limicola,,periphery
+290317,Chlorobium phaeobacteroides DSM266,Chlorobium phaeobacteroides DSM266,,periphery
+290318,Chlorobium phaeovibrioides DSM265,Chlorobium phaeovibrioides,,periphery
+290340,Arthrobacter aurescens TC1,Arthrobacter aurescens,,periphery
+290397,Anaeromyxobacter dehalogenans 2CP-C,Anaeromyxobacter dehalogenans,,core
+290398,Chromohalobacter salexigens DSM3043,Chromohalobacter salexigens,,core
+290399,Arthrobacter sp. FB24,Arthrobacter sp. FB24,,periphery
+290400,Jannaschia sp. CCS1,Jannaschia sp. CCS1,,core
+290402,Clostridium beijerinckii NCIMB 8052,Clostridium beijerinckii,,core
+290434,Borrelia garinii PBi,Borrelia garinii,,periphery
+290512,Prosthecochloris aestuarii DSM271,Prosthecochloris aestuarii,,core
+290633,Gluconobacter oxydans 621H,Gluconobacter oxydans 621H,,core
+291112,Photorhabdus asymbiotica,Photorhabdus asymbiotica,,core
+291272,Candidatus Blochmannia pennsylvanicus str. BPEN,Blochmannia pennsylvanicus,,periphery
+291985,Erythrobacter vulgaris,Erythrobacter vulgaris,,periphery
+292414,Ruegeria sp. TM1040,Ruegeria sp. TM1040,,core
+292415,Thiobacillus denitrificans ATCC25259,Thiobacillus denitrificans ATCC25259,,core
+292459,Symbiobacterium thermophilum IAM 14863,Symbiobacterium thermophilum,,core
+292563,Cyanobacterium stanieri PCC7202,Cyanobacterium stanieri,,periphery
+292564,Cyanobium gracile PCC6307,Cyanobium gracile,,periphery
+292805,Wolbachia endosymbiont strain TRS of Brugia malayi,Wolbachia sp. Bma,,periphery
+293227,Cyphellophora europaea,Cyphellophora europaea,,periphery
+293613,Rickettsia canadensis str. McKiel,Rickettsia canadensis,,periphery
+293614,Rickettsia akari str. Hartford,Rickettsia akari,,periphery
+293826,Alkaliphilus metalliredigens QYMF,Alkaliphilus metalliredigens,,core
+295358,Mycoplasma hyopneumoniae 232,Mycoplasma hyopneumoniae 232,,periphery
+296587,Micromonas sp. RCC299,Micromonas sp. RCC299,,periphery
+296591,Polaromonas sp. JS666,Polaromonas sp. JS666,,core
+297246,Legionella pneumophila str. Paris,Legionella pneumophila Paris,,core
+298386,Photobacterium profundum SS9,Photobacterium profundum,,core
+298653,Frankia sp. EAN1pec,Frankia sp. EAN1pec,,core
+298654,Frankia sp. EuI1c,Frankia sp. EuI1c,,periphery
+298655,Frankia sp. CN3,Frankia sp. CN3,,periphery
+300852,Thermus thermophilus HB8,Thermus thermophilus HB8,,periphery
+303518,Pundamilia nyererei,Pundamilia nyererei,,periphery
+304371,Methanocella paludicola SANAE,Methanocella paludicola,,periphery
+305700,Thauera sp. 27,Thauera sp. 27,,core
+305900,Endozoicomonas elysicola,Endozoicomonas elysicola,,periphery
+306263,Campylobacter lari RM2100,Campylobacter lari,,periphery
+306264,Campylobacter upsaliensis RM3195,Campylobacter upsaliensis,,periphery
+306281,Fischerella muscicola PCC7414,Fischerella muscicola,,periphery
+306537,Corynebacterium jeikeium K411,Corynebacterium jeikeium,,periphery
+307480,Chryseobacterium vrystaatense,Chryseobacterium vrystaatense,,core
+309798,Coprothermobacter proteolyticus DSM5265,Coprothermobacter proteolyticus,,periphery
+309799,Dictyoglomus thermophilum H-6-12,Dictyoglomus thermophilum,,core
+309800,Haloferax volcanii DS2,Haloferax volcanii,,periphery
+309801,Thermomicrobium roseum DSM5159,Thermomicrobium roseum,,periphery
+309803,Thermotoga neapolitana DSM4359,Thermotoga neapolitana,,periphery
+309807,Salinibacter ruber DSM13855,Salinibacter ruber,,periphery
+310453,Neofusicoccum parvum,Neofusicoccum parvum,,core
+311402,Agrobacterium vitis S4,Agrobacterium vitis,,periphery
+311403,Agrobacterium radiobacter K84,Agrobacterium radiobacter,,periphery
+311424,Dehalococcoides mccartyi VS,Dehalococcoides mccartyi VS,,periphery
+312153,Polynucleobacter necessarius subsp. asymbioticus QLW-P1DMWA-1,Polynucleobacter necessarius asymbioticus,,core
+312284,marine actinobacterium PHSC20C1,actinobacterium PHSC20C1,,periphery
+312309,Vibrio fischeri ES114,Vibrio fischeri,,core
+313589,Janibacter sp. HTCC2649,Janibacter sp. HTCC2649,,core
+313590,Dokdonia sp. MED134,Dokdonia sp. MED134,,core
+313594,Polaribacter irgensii 23-P,Polaribacter irgensii,,periphery
+313595,Psychroflexus torquis ATCC700755,Psychroflexus torquis,,core
+313596,Robiginitalea biformata HTCC2501,Robiginitalea biformata,,core
+313598,Polaribacter sp. MED152,Polaribacter sp. MED152,,core
+313603,Maribacter sp. HTCC2170,Maribacter sp. HTCC2170,,core
+313606,Microscilla marina ATCC23134,Microscilla marina,,core
+313612,Lyngbya sp. PCC8106,Lyngbya sp. PCC8106,,core
+313624,Nodularia spumigena CCY9414,Nodularia spumigena,,periphery
+313625,Synechococcus sp. BL107,Synechococcus sp. BL107,,periphery
+313628,Lentisphaera araneosa HTCC2155,Lentisphaera araneosa,,core
+314225,Erythrobacter litoralis HTCC2594,Erythrobacter litoralis,,periphery
+314230,Blastopirellula marina DSM3645,Blastopirellula marina,,core
+314231,Fulvimarina pelagi HTCC2506,Fulvimarina pelagi,,core
+314232,Loktanella vestfoldensis SKA53,Loktanella vestfoldensis SKA53,,core
+314254,Oceanicaulis sp. HTCC2633,Oceanicaulis sp. HTCC2633,,core
+314256,Oceanicola granulosus HTCC2516,Oceanicola granulosus,,periphery
+314260,Parvularcula bermudensis HTCC2503,Parvularcula bermudensis,,core
+314262,Roseobacter sp. MED193,Roseobacter sp. MED193,,core
+314264,Roseovarius sp. 217,Roseovarius sp. 217,,core
+314265,Pelagibaca bermudensis HTCC2601,Pelagibaca bermudensis,,core
+314266,Sphingomonas sp. SKA58,Sphingomonas sp. SKA58,,periphery
+314270,Rhodobacteraceae bacterium HTCC2083,Rhodobacteraceae bacterium HTCC2083,,periphery
+314271,Maritimibacter alkaliphilus HTCC2654,Maritimibacter alkaliphilus,,core
+314275,Alteromonas macleodii str. 'Deep ecotype',Alteromonas macleodii Deep,,core
+314278,Nitrococcus mobilis Nb-231,Nitrococcus mobilis,,core
+314282,Psychromonas sp. CNPT3,Psychromonas sp. CNPT3,,periphery
+314285,Congregibacter litoralis KT71,Congregibacter litoralis,,core
+314287,gamma proteobacterium HTCC2207,Gammaproteobacteria bacterium HTCC2207,,periphery
+314292,Photobacterium angustum S14,Photobacterium angustum,,core
+314315,Lactobacillus sakei subsp. sakei 23K,Lactobacillus sakei,,periphery
+314345,Mariprofundus ferrooxydans PV-1,Mariprofundus ferrooxydans,,core
+314607,beta proteobacterium KB13,beta proteobacterium KB13,,periphery
+314723,Borrelia hermsii HS1,Borrelia hermsii,,periphery
+314724,Borrelia turicatae 91E135,Borrelia turicatae,,periphery
+315456,Rickettsia felis URRWXCal2,Rickettsia felis,,periphery
+315730,Bacillus weihenstephanensis KBAB4,Bacillus weihenstephanensis,,periphery
+315749,Bacillus cytotoxicus NVH 391-98,Bacillus cytotoxicus,,periphery
+315750,Bacillus pumilus SAFR-032,Bacillus pumilus,,core
+316055,Rhodopseudomonas palustris BisA53,Rhodopseudomonas palustris BisA53,,periphery
+316056,Rhodopseudomonas palustris BisB18,Rhodopseudomonas palustris BisB18,,periphery
+316057,Rhodopseudomonas palustris BisB5,Rhodopseudomonas palustris BisB5,,periphery
+316058,Rhodopseudomonas palustris HaA2,Rhodopseudomonas palustris HaA2,,periphery
+316067,Geobacter daltonii FRC-32,Geobacter daltonii,,periphery
+316273,Xanthomonas campestris pv. vesicatoria str. 85-10,Xanthomonas campestris vesicatoria,,periphery
+316274,Herpetosiphon aurantiacus DSM785,Herpetosiphon aurantiacus,,core
+316275,Aliivibrio salmonicida LFI1238,Aliivibrio salmonicida,,periphery
+316278,Synechococcus sp. RCC307,Synechococcus sp. RCC307,,periphery
+316279,Synechococcus sp. CC9902,Synechococcus sp. CC9902,,periphery
+316407,Escherichia coli str. K-12 substr. W3110,Escherichia coli K12 W3110,,periphery
+317013,Xanthomonas axonopodis pv. phaseoli,Xanthomonas axonopodis phaseoli,,periphery
+317025,Thiomicrospira crunogena XCL-2,Thiomicrospira crunogena,,core
+317619,Prochlorothrix hollandica PCC9006,Prochlorothrix hollandica,,core
+317655,Sphingopyxis alaskensis RB2256,Sphingopyxis alaskensis,,core
+317936,Nostoc sp. PCC7107,Nostoc sp. PCC7107,,periphery
+318161,Shewanella denitrificans OS217,Shewanella denitrificans,,periphery
+318167,Shewanella frigidimarina NCIMB 400,Shewanella frigidimarina,,periphery
+318424,Mycobacterium rufum,Mycobacterium rufum,,periphery
+318464,Clostridium sulfidigenes,Clostridium sulfidigenes,,periphery
+318586,Paracoccus denitrificans PD1222,Paracoccus denitrificans,,core
+318829,Magnaporthe oryzae,Magnaporthe oryzae,,core
+318996,Bradyrhizobium sp. WSM1743,Bradyrhizobium sp. WSM1743,,periphery
+319003,Bradyrhizobium sp. WSM1253,Bradyrhizobium sp. WSM1253,,periphery
+319224,Shewanella putrefaciens CN-32,Shewanella putrefaciens,,core
+319225,Chlorobium luteolum DSM273,Chlorobium luteolum,,periphery
+319236,Nonlabens sediminis,Nonlabens sediminis,,periphery
+319795,Deinococcus geothermalis DSM11300,Deinococcus geothermalis,,core
+320483,Anaplasma marginale str. Florida,Anaplasma marginale Florida,,periphery
+321327,Synechococcus sp. JA-3-3Ab,Synechococcus sp. JA33Ab,,core
+321332,Synechococcus sp. JA-2-3Ba(2-13),Synechococcus sp. JA23Ba,,periphery
+321846,Pseudomonas simiae,Pseudomonas simiae,,periphery
+321955,Brevibacterium linens BL2,Brevibacterium linens,,periphery
+321961,Wheat blue dwarf phytoplasma,Phytoplasma wheat blue,,core
+322098,Aster yellows witches'-broom phytoplasma AYWB,Phytoplasma aster yellows,,periphery
+322159,Streptococcus thermophilus LMD-9,Streptococcus thermophilus LMD9,,periphery
+322710,Azotobacter vinelandii DJ,Azotobacter vinelandii,,core
+323097,Nitrobacter hamburgensis X14,Nitrobacter hamburgensis,,core
+323098,Nitrobacter winogradskyi Nb-255,Nitrobacter winogradskyi,,periphery
+323259,Methanospirillum hungatei JF-1,Methanospirillum hungatei,,periphery
+323261,Nitrosococcus oceani ATCC19707,Nitrosococcus oceani,,core
+323848,Nitrosospira multiformis ATCC25196,Nitrosospira multiformis,,core
+323850,Shewanella loihica PV-4,Shewanella loihica,,periphery
+324057,Paenibacillus sp. JDR-2,Paenibacillus sp. JDR2,,periphery
+324602,Chloroflexus aurantiacus J-10-fl,Chloroflexus aurantiacus,,periphery
+324831,Lactobacillus gasseri ATCC33323,Lactobacillus gasseri,,periphery
+324925,Pelodictyon phaeoclathratiforme BU-1,Pelodictyon phaeoclathratiforme,,core
+325452,Phytophthora kernoviae,Phytophthora kernoviae,,periphery
+325777,Xanthomonas axonopodis pv. vasculorum,Xanthomonas axonopodis vasculorum,,periphery
+326297,Shewanella amazonensis SB2B,Shewanella amazonensis,,periphery
+326298,Sulfurimonas denitrificans DSM1251,Sulfurimonas denitrificans,,core
+326423,Bacillus amyloliquefaciens subsp. plantarum str. FZB42,Bacillus amyloliquefaciens,,periphery
+326424,Frankia alni ACN14a,Frankia alni,,periphery
+326425,Lactobacillus helveticus CNRZ32,Lactobacillus helveticus CNRZ32,,periphery
+326426,Bifidobacterium breve UCC2003,Bifidobacterium breve,,periphery
+326427,Chloroflexus aggregans DSM9485,Chloroflexus aggregans,,periphery
+326442,Pseudoalteromonas haloplanktis TAC125,Pseudoalteromonas haloplanktis TAC125,,core
+327079,Pseudozyma hubeiensis,Pseudozyma hubeiensis,,periphery
+327277,Bifidobacterium crudilactis,Bifidobacterium crudilactis,,periphery
+329726,Acaryochloris marina MBIC11017,Acaryochloris marina,,core
+330084,Amycolatopsis jejuensis,Amycolatopsis jejuensis,,periphery
+330214,Candidatus Nitrospira defluvii,Nitrospira defluvii,,core
+330779,Sulfolobus acidocaldarius DSM639,Sulfolobus acidocaldarius,,periphery
+331104,Blattabacterium sp. (Blattella germanica),Blattabacterium sp. Bge,,core
+331113,Simkania negevensis Z,Simkania negevensis,,core
+331635,Chlamydophila pecorum E58,Chlamydophila pecorum,,periphery
+331636,Chlamydia psittaci 6BC,Chlamydia psittaci 6BC,,core
+331678,Chlorobium phaeobacteroides BS1,Chlorobium phaeobacteroides BS1,,periphery
+331869,alpha proteobacterium BAL199,alpha proteobacterium BAL199,,periphery
+332101,Clostridium drakei,Clostridium drakei,,periphery
+333138,Bacillus okhensis,Bacillus okhensis,,periphery
+334390,Lactobacillus fermentum IFO 3956,Lactobacillus fermentum IFO3956,,periphery
+334413,Finegoldia magna ATCC29328,Finegoldia magna ATCC29328,,core
+334545,Rickettsia tamurae,Rickettsia tamurae,,core
+335283,Nitrosomonas eutropha C91,Nitrosomonas eutropha,,core
+335284,Psychrobacter cryohalolentis K5,Psychrobacter cryohalolentis,,core
+335541,Syntrophomonas wolfei subsp. wolfei str. Goettingen G311,Syntrophomonas wolfei,,periphery
+335543,Syntrophobacter fumaroxidans MPOB,Syntrophobacter fumaroxidans,,core
+335659,Bradyrhizobium sp. S23321,Bradyrhizobium sp. S23321,,periphery
+335992,Candidatus Pelagibacter ubique HTCC1062,Pelagibacter ubique HTCC1062,,periphery
+336407,Rickettsia bellii RML369-C,Rickettsia bellii RML369C,,periphery
+337075,Pyronema omphalodes,Pyronema omphalodes,,core
+337191,Gordonia sp. KTR9,Gordonia sp. KTR9,,periphery
+338963,Pelobacter carbinolicus DSM2380,Pelobacter carbinolicus,,core
+338966,Pelobacter propionicus DSM2379,Pelobacter propionicus,,periphery
+338969,Rhodoferax ferrireducens T118,Rhodoferax ferrireducens,,core
+339670,Burkholderia ambifaria AMMD,Burkholderia ambifaria,,periphery
+339671,Actinobacillus succinogenes 130Z,Actinobacillus succinogenes,,periphery
+339860,Methanosphaera stadtmanae DSM3091,Methanosphaera stadtmanae,,core
+340099,Thermoanaerobacter pseudethanolicus ATCC33223,Thermoanaerobacter pseudethanolicus,,periphery
+340170,Spathaspora passalidarum,Spathaspora passalidarum,,periphery
+340177,Chlorobium chlorochromatii CaD3,Chlorobium chlorochromatii,,core
+342113,Burkholderia oklahomensis,Burkholderia oklahomensis,,periphery
+342451,Staphylococcus saprophyticus subsp. saprophyticus ATCC15305,Staphylococcus saprophyticus,,core
+342610,Pseudoalteromonas atlantica T6c,Pseudoalteromonas atlantica,,core
+342949,Pyrococcus sp. NA2,Pyrococcus sp. NA2,,core
+343509,Sodalis glossinidius str. 'morsitans',Sodalis glossinidius,,core
+344747,Planctomyces maris DSM8797,Planctomyces maris,,core
+345073,Vibrio cholerae O395,Vibrio cholerae O395,,periphery
+345219,Bacillus coagulans 36D1,Bacillus coagulans 36D1,,periphery
+345341,Kutzneria sp. 744,Kutzneria sp. 744,,periphery
+347256,Mycoplasma hominis ATCC23114,Mycoplasma hominis,,core
+347834,Rhizobium etli CFN 42,Rhizobium etli CFN42,,periphery
+348780,Natronomonas pharaonis DSM2160,Natronomonas pharaonis,,core
+348824,Rhizobium sp. LPU83,Rhizobium sp. LPU83,,periphery
+349102,Rhodobacter sphaeroides ATCC17025,Rhodobacter sphaeroides ATCC17025,,core
+349106,Psychrobacter sp. PRwf-1,Psychrobacter sp. PRwf1,,periphery
+349123,Lactobacillus reuteri 100-23,Lactobacillus reuteri 10023,,periphery
+349124,Halorhodospira halophila SL1,Halorhodospira halophila,,core
+349161,Desulfotomaculum reducens MI-1,Desulfotomaculum reducens,,periphery
+349163,Acidiphilium cryptum JF-5,Acidiphilium cryptum,,core
+349519,Leuconostoc citreum KM20,Leuconostoc citreum,,periphery
+349520,Paenibacillus polymyxa E681,Paenibacillus polymyxa E681,,periphery
+349521,Hahella chejuensis KCTC 2396,Hahella chejuensis,,core
+349741,Akkermansia muciniphila ATCC BAA-835,Akkermansia muciniphila,,core
+349965,Yersinia intermedia ATCC29909,Yersinia intermedia,,periphery
+349966,Yersinia frederiksenii ATCC33641,Yersinia frederiksenii,,periphery
+350054,Mycobacterium gilvum PYR-GCK,Mycobacterium gilvum,,periphery
+350058,Mycobacterium vanbaalenii PYR-1,Mycobacterium vanbaalenii,,periphery
+350688,Alkaliphilus oremlandii OhILAs,Alkaliphilus oremlandii,,periphery
+351016,Roseobacter sp. AzwK-3b,Roseobacter sp. AzwK3b,,core
+351160,Methanocella arvoryzae MRE50,Methanocella arvoryzae,,periphery
+351348,Marinobacter hydrocarbonoclasticus VT8,Marinobacter hydrocarbonoclasticus,,core
+351607,Acidothermus cellulolyticus 11B,Acidothermus cellulolyticus,,core
+351627,Caldicellulosiruptor saccharolyticus DSM8903,Caldicellulosiruptor saccharolyticus,,periphery
+351746,Pseudomonas putida F1,Pseudomonas putida F1,,core
+352165,Pyramidobacter piscolens W5455,Pyramidobacter piscolens,,core
+353496,Lactobacillus delbrueckii subsp. bulgaricus 2038,Lactobacillus delbrueckii 2038,,periphery
+354242,Campylobacter jejuni subsp. jejuni 81-176,Campylobacter jejuni 81176,,periphery
+356829,Bifidobacterium tsurumiense,Bifidobacterium tsurumiense,,periphery
+356851,Micromonospora chokoriensis,Micromonospora chokoriensis,,periphery
+357244,Orientia tsutsugamushi str. Boryong,Orientia tsutsugamushi,,core
+357276,Bacteroides dorei,Bacteroides dorei,,core
+357804,Psychromonas ingrahamii 37,Psychromonas ingrahamii,,core
+357808,Roseiflexus sp. RS-1,Roseiflexus sp. RS1,,core
+357809,Lachnoclostridium phytofermentans ISDg,Lachnoclostridium phytofermentans,,periphery
+358220,Acidovorax sp. KKS102,Acidovorax sp. KKS102,,periphery
+358396,Halobiforma lacisalsi AJ5,Halobiforma lacisalsi,,periphery
+358681,Brevibacillus brevis NBRC 100599,Brevibacillus brevis NBRC100599,,core
+358823,Streptomyces olindensis,Streptomyces olindensis,,periphery
+360094,Xanthomonas oryzae pv. oryzae PXO99A,Xanthomonas oryzae PXO99A,,periphery
+360095,Bartonella bacilliformis KC583,Bartonella bacilliformis,,core
+360104,Campylobacter concisus 13826,Campylobacter concisus 13826,,periphery
+360106,Campylobacter fetus subsp. fetus 82-40,Campylobacter fetus 8240,,periphery
+360107,Campylobacter hominis ATCC BAA-381,Campylobacter hominis,,periphery
+360910,Bordetella avium 197N,Bordetella avium,,periphery
+360911,Exiguobacterium sp. AT1b,Exiguobacterium sp. AT1b,,core
+362242,Mycobacterium ulcerans Agy99,Mycobacterium ulcerans,,periphery
+362418,Flavobacterium reichenbachii,Flavobacterium reichenbachii,,periphery
+362663,Escherichia coli 536,Escherichia coli 536,,periphery
+362976,Haloquadratum walsbyi DSM16790,Haloquadratum walsbyi DSM16790,,core
+363253,Lawsonia intracellularis PHE/MN1-00,Lawsonia intracellularis,,core
+364733,Endocarpon pusillum,Endocarpon pusillum,,periphery
+365044,Polaromonas naphthalenivorans CJ2,Polaromonas naphthalenivorans,,periphery
+365046,Ramlibacter tataouinensis TTB310,Ramlibacter tataouinensis,,core
+365528,Frankia sp. BCU110501,Frankia sp. BCU110501,,core
+365659,Streptococcus mitis B6,Streptococcus mitis B6,,periphery
+366394,Sinorhizobium medicae WSM419,Sinorhizobium medicae,,core
+366602,Caulobacter sp. K31,Caulobacter sp. K31,,core
+366649,Xanthomonas fuscans subsp. fuscans,Xanthomonas fuscans,,periphery
+367299,Phycicoccus jejuensis,Phycicoccus jejuensis,,periphery
+367336,Rhodobacterales bacterium HTCC2255,Rhodobacterales bacterium HTCC2255,,periphery
+367737,Arcobacter butzleri RM4018,Arcobacter butzleri RM4018,,core
+368407,Methanoculleus marisnigri JR1,Methanoculleus marisnigri,,periphery
+368408,Thermofilum pendens Hrk 5,Thermofilum pendens,,core
+369723,Salinispora tropica CNB-440,Salinispora tropica,,core
+370438,Pelotomaculum thermopropionicum SI,Pelotomaculum thermopropionicum,,core
+371042,Erwinia typographi,Erwinia typographi,,periphery
+371731,Rhodobacter sp. SW2,Rhodobacter sp. SW2,,core
+372461,Buchnera aphidicola str. BCc,Buchnera aphidicola BCc,,periphery
+373153,Streptococcus pneumoniae D39,Streptococcus pneumoniae D39,,core
+373903,Halothermothrix orenii H 168,Halothermothrix orenii,,core
+373994,Rivularia sp. PCC7116,Rivularia sp. PCC7116,,periphery
+374847,Candidatus Korarchaeum cryptofilum OPF8,Korarchaeum cryptofilum,,core
+375286,Janthinobacterium sp. Marseille,Janthinobacterium sp. Marseille,,core
+375451,Roseobacter denitrificans OCh 114,Roseobacter denitrificans,,periphery
+376619,Francisella tularensis subsp. holarctica LVS,Francisella tularensis holarctica,,core
+376686,Flavobacterium johnsoniae UW101,Flavobacterium johnsoniae,,core
+376733,Paracoccus halophilus,Paracoccus halophilus,,periphery
+377629,Teredinibacter turnerae T7901,Teredinibacter turnerae T7901,,core
+378753,Kocuria rhizophila DC2201,Kocuria rhizophila DC2201,,core
+378806,Stigmatella aurantiaca DW4/3-1,Stigmatella aurantiaca,,core
+379066,Gemmatimonas aurantiaca T-27,Gemmatimonas aurantiaca,,core
+379731,Pseudomonas stutzeri A1501,Pseudomonas stutzeri A1501,,core
+380358,Xanthomonas albilineans GPE PC73,Xanthomonas albilineans,,periphery
+380394,Acidithiobacillus ferrooxidans ATCC53993,Acidithiobacillus ferrooxidans ATCC53993,,periphery
+380703,Aeromonas hydrophila subsp. hydrophila ATCC7966,Aeromonas hydrophila ATCC7966,,periphery
+380749,Hydrogenobaculum sp. Y04AAS1,Hydrogenobaculum sp. Y04AAS1,,periphery
+381046,Lachancea thermotolerans,Lachancea thermotolerans,,core
+381666,Ralstonia eutropha H16,Ralstonia eutropha H16,,core
+381764,Fervidobacterium nodosum Rt17-B1,Fervidobacterium nodosum,,periphery
+382245,Aeromonas salmonicida subsp. salmonicida A449,Aeromonas salmonicida,,core
+382464,Verrucomicrobiae bacterium DG1235,Verrucomicrobiae bacterium DG1235,,periphery
+382638,Helicobacter acinonychis str. Sheeba,Helicobacter acinonychis,,periphery
+382640,Bartonella tribocorum CIP 105476,Bartonella tribocorum,,core
+383372,Roseiflexus castenholzii DSM13941,Roseiflexus castenholzii,,periphery
+383381,Erythrobacter sp. JL475,Erythrobacter sp. JL475,,periphery
+383407,Xanthomonas oryzae pv. oryzicola BLS256,Xanthomonas oryzae oryzicola,,core
+384616,Pyrobaculum islandicum DSM4184,Pyrobaculum islandicum,,periphery
+384676,Pseudomonas entomophila L48,Pseudomonas entomophila,,periphery
+384765,Labrenzia aggregata IAM 12614,Labrenzia aggregata,,core
+385682,Thermophagus xiamenensis,Thermophagus xiamenensis,,core
+386043,Listeria welshimeri serovar 6b str. SLCC5334,Listeria welshimeri,,core
+386415,Clostridium novyi NT,Clostridium novyi NT,,core
+386456,Methanobacterium arcticum,Methanobacterium arcticum,,periphery
+387092,Nitratiruptor sp. SB155-2,Nitratiruptor sp. SB1552,,core
+387093,Sulfurovum sp. NBC37-1,Sulfurovum sp. NBC371,,core
+387344,Lactobacillus brevis ATCC367,Lactobacillus brevis ATCC367,,periphery
+387631,Archaeoglobus sulfaticallidus PM70-1,Archaeoglobus sulfaticallidus,,periphery
+388051,Cupriavidus sp. amp6,Cupriavidus sp. amp6,,periphery
+388399,Sagittula stellata E-37,Sagittula stellata,,core
+388401,Rhodobacteraceae bacterium HTCC2150,Rhodobacteraceae bacterium HTCC2150,,periphery
+388413,Algoriphagus machipongonensis,Algoriphagus machipongonensis,,core
+388467,Planktothrix agardhii NIVA-CYA 126/8,Planktothrix agardhii,,core
+388739,Roseobacter sp. SK209-2-6,Roseobacter sp. SK20926,,periphery
+388919,Streptococcus sanguinis SK36,Streptococcus sanguinis SK36,,periphery
+390235,Pseudomonas putida W619,Pseudomonas putida W619,,periphery
+390236,Borrelia afzelii PKo,Borrelia afzelii,,core
+390333,Lactobacillus delbrueckii subsp. bulgaricus ATCC11842,Lactobacillus delbrueckii ATCC11842,,periphery
+390874,Thermotoga petrophila RKU-1,Thermotoga petrophila,,periphery
+390989,Actinocatenispora sera,Actinocatenispora sera,,periphery
+391008,Stenotrophomonas maltophilia R551-3,Stenotrophomonas maltophilia R5513,,core
+391009,Thermosipho melanesiensis BI429,Thermosipho melanesiensis,,periphery
+391036,Ehrlichia sp. HF,Ehrlichia sp. HF,,periphery
+391037,Salinispora arenicola CNS-205,Salinispora arenicola,,periphery
+391038,Burkholderia phymatum STM815,Burkholderia phymatum,,periphery
+391165,Granulibacter bethesdensis CGDNIH1,Granulibacter bethesdensis,,core
+391295,Streptococcus suis 05ZYH33,Streptococcus suis 05ZYH33,,periphery
+391587,Kordia algicida OT-1,Kordia algicida,,core
+391589,Roseobacter sp. GAI101,Roseobacter sp. GAI101,,periphery
+391593,Roseobacter sp. CCS2,Roseobacter sp. CCS2,,periphery
+391595,Roseobacter litoralis Och 149,Roseobacter litoralis,,periphery
+391596,Pedobacter sp. BAL39,Pedobacter sp. BAL39,,core
+391598,Flavobacteria bacterium BAL38,Flavobacteria bacterium BAL38,,periphery
+391600,Brevundimonas sp. BAL3,Brevundimonas sp. BAL3,,core
+391603,Flavobacteriales bacterium ALC-1,Flavobacteriales bacterium ALC1,,core
+391612,Cyanothece sp. CCY0110,Cyanothece sp. CCY0110,,periphery
+391613,Roseovarius sp. TM1035,Roseovarius sp. TM1035,,core
+391615,gamma proteobacterium HTCC5015,Gammaproteobacteria bacterium HTCC5015,,periphery
+391616,Octadecabacter arcticus 238,Octadecabacter arcticus,,core
+391619,Phaeobacter inhibens DSM17395,Phaeobacter inhibens,,core
+391623,Thermococcus barophilus MP,Thermococcus barophilus,,periphery
+391624,Oceanibulbus indolifex HEL-45,Oceanibulbus indolifex,,core
+391625,Plesiocystis pacifica SIR-1,Plesiocystis pacifica,,periphery
+391626,Octadecabacter antarcticus 307,Octadecabacter antarcticus,,periphery
+391735,Verminephrobacter eiseniae EF01-2,Verminephrobacter eiseniae,,core
+391896,Rickettsia bellii OSU 85-389,Rickettsia bellii OSU85389,,periphery
+391937,Nitratireductor pacificus pht-3B,Nitratireductor pacificus,,core
+392499,Sphingomonas wittichii RW1,Sphingomonas wittichii,,core
+392500,Shewanella woodyi ATCC51908,Shewanella woodyi,,periphery
+393283,Pestalotiopsis fici,Pestalotiopsis fici,,periphery
+393305,Yersinia enterocolitica subsp. enterocolitica 8081,Yersinia enterocolitica 8081,,core
+393480,Fusobacterium nucleatum subsp. polymorphum ATCC10953,Fusobacterium nucleatum polymorphum,,core
+393595,Alcanivorax borkumensis SK2,Alcanivorax borkumensis,,core
+393921,Porphyromonas crevioricanis,Porphyromonas crevioricanis,,periphery
+394221,Maricaulis maris MCS10,Maricaulis maris,,core
+394503,Clostridium cellulolyticum H10,Clostridium cellulolyticum,,core
+395019,Burkholderia multivorans ATCC17616,Burkholderia multivorans,,periphery
+395492,Rhizobium leguminosarum bv. trifolii WSM2304,Rhizobium leguminosarum WSM2304,,periphery
+395493,Beggiatoa alba B18LD,Beggiatoa alba,,periphery
+395494,Gallionella capsiferriformans ES-2,Gallionella capsiferriformans,,periphery
+395495,Leptothrix cholodnii SP-6,Leptothrix cholodnii,,core
+395961,Cyanothece sp. PCC7425,Cyanothece sp. PCC7425,,periphery
+395963,Beijerinckia indica subsp. indica ATCC9039,Beijerinckia indica,,core
+395964,Methylocapsa acidiphila B2,Methylocapsa acidiphila,,periphery
+395965,Methylocella silvestris BL2,Methylocella silvestris,,core
+396014,Brachybacterium phenoliresistens,Brachybacterium phenoliresistens,,core
+396513,Staphylococcus carnosus subsp. carnosus TM300,Staphylococcus carnosus,,core
+396588,Thioalkalivibrio sulfidiphilus HL-EbGr7,Thioalkalivibrio sulfidiphilus,,periphery
+396595,Thioalkalivibrio sp. K90mix,Thioalkalivibrio sp. K90mix,,core
+397278,Marmoricola aequoreus,Marmoricola aequoreus,,periphery
+397287,Lachnospiraceae bacterium 28-4,Lachnospiraceae bacterium 284,,periphery
+397288,Lachnospiraceae bacterium 3-1,Lachnospiraceae bacterium 31,,periphery
+397290,Lachnospiraceae bacterium A2,Lachnospiraceae bacterium A2,,periphery
+397291,Lachnospiraceae bacterium A4,Lachnospiraceae bacterium A4,,periphery
+397945,Acidovorax citrulli AAC00-1,Acidovorax citrulli,,periphery
+397948,Caldivirga maquilingensis IC-167,Caldivirga maquilingensis,,periphery
+398511,Bacillus pseudofirmus OF4,Bacillus pseudofirmus,,periphery
+398512,Pseudobacteroides cellulosolvens ATCC35603,Pseudobacteroides cellulosolvens,,core
+398513,Bifidobacterium bifidum NCIMB 41171,Bifidobacterium bifidum NCIMB41171,,periphery
+398525,Bradyrhizobium elkanii USDA 76,Bradyrhizobium elkanii USDA76,,periphery
+398527,Burkholderia phytofirmans PsJN,Burkholderia phytofirmans,,periphery
+398578,Delftia acidovorans SPH-1,Delftia acidovorans,,core
+398579,Shewanella pealeana ATCC700345,Shewanella pealeana,,periphery
+398580,Dinoroseobacter shibae DFL12,Dinoroseobacter shibae,,core
+398720,Leeuwenhoekiella blandensis MED217,Leeuwenhoekiella blandensis,,core
+398767,Geobacter lovleyi SZ,Geobacter lovleyi,,periphery
+399549,Metallosphaera sedula DSM5348,Metallosphaera sedula,,periphery
+399550,Staphylothermus marinus F1,Staphylothermus marinus,,core
+399739,Pseudomonas mendocina ymp,Pseudomonas mendocina ymp,,periphery
+399741,Serratia proteamaculans 568,Serratia proteamaculans,,core
+399742,Enterobacter sp. 638,Enterobacter sp. 638,,periphery
+399795,Comamonas testosteroni KF-1,Comamonas testosteroni KF1,,core
+400668,Marinomonas sp. MWYL1,Marinomonas sp. MWYL1,,core
+400682,Amphimedon queenslandica,Amphimedon queenslandica,,core
+401053,Terriglobus saanensis SP1PR4,Terriglobus saanensis,,core
+401473,Bifidobacterium dentium Bd1,Bifidobacterium dentium,,periphery
+401526,Thermosinus carboxydivorans Nor1,Thermosinus carboxydivorans,,core
+402612,Flavobacterium psychrophilum JIP02/86,Flavobacterium psychrophilum,,periphery
+402626,Ralstonia pickettii 12J,Ralstonia pickettii 12J,,core
+402777,Kamptonema formosum PCC6407,Kamptonema formosum,,core
+402880,Methanococcus maripaludis C5,Methanococcus maripaludis C5,,periphery
+402881,Parvibaculum lavamentivorans DS-1,Parvibaculum lavamentivorans,,core
+403833,Petrotoga mobilis SJ95,Petrotoga mobilis,,core
+404380,Geobacter bemidjiensis Bem,Geobacter bemidjiensis,,periphery
+404589,Anaeromyxobacter sp. Fw109-5,Anaeromyxobacter sp. Fw1095,,periphery
+405566,Lactobacillus helveticus DPC 4571,Lactobacillus helveticus DPC4571,,periphery
+405948,Saccharopolyspora erythraea NRRL 2338,Saccharopolyspora erythraea,,core
+406124,Bacillus sp. m3-13,Bacillus sp. m313,,periphery
+406327,Methanococcus vannielii SB,Methanococcus vannielii,,core
+406552,Natrinema sp. J7-2,Natrinema sp. J72,,periphery
+406817,Xenorhabdus nematophila ATCC19061,Xenorhabdus nematophila,,periphery
+406818,Xenorhabdus bovienii SS-2004,Xenorhabdus bovienii,,core
+408672,Nocardioidaceae bacterium Broad-1,Nocardioidaceae bacterium Broad1,,periphery
+410358,Methanocorpusculum labreanum Z,Methanocorpusculum labreanum,,periphery
+410359,Pyrobaculum calidifontis JCM 11548,Pyrobaculum calidifontis,,periphery
+411154,Gramella forsetii KT0803,Gramella forsetii,,core
+411459,Ruminococcus obeum ATCC29174,Ruminococcus obeum ATCC29174,,periphery
+411460,Ruminococcus torques ATCC27756,Ruminococcus torques ATCC27756,,periphery
+411461,Dorea formicigenerans ATCC27755,Dorea formicigenerans ATCC27755,,core
+411462,Dorea longicatena DSM13814,Dorea longicatena DSM13814,,core
+411463,Eubacterium ventriosum ATCC27560,Eubacterium ventriosum,,core
+411464,Desulfovibrio piger ATCC29098,Desulfovibrio piger,,periphery
+411465,Parvimonas micra ATCC33270,Parvimonas micra,,core
+411466,Actinomyces odontolyticus ATCC17982,Actinomyces odontolyticus,,periphery
+411467,Pseudoflavonifractor capillosus ATCC29799,Pseudoflavonifractor capillosus,,core
+411468,[Clostridium] scindens ATCC35704,Clostridium scindens,,periphery
+411469,[Eubacterium] hallii DSM3353,Eubacterium hallii,,core
+411470,Ruminococcus gnavus ATCC29149,Ruminococcus gnavus,,periphery
+411471,Subdoligranulum variabile DSM15176,Subdoligranulum variabile,,core
+411473,Ruminococcus callidus ATCC27760,Ruminococcus callidus,,periphery
+411474,Coprococcus eutactus ATCC27759,Coprococcus eutactus,,core
+411476,Bacteroides ovatus ATCC8483,Bacteroides ovatus,,periphery
+411477,Parabacteroides merdae ATCC43184,Parabacteroides merdae,,core
+411479,Bacteroides uniformis ATCC8492,Bacteroides uniformis,,periphery
+411483,Faecalibacterium prausnitzii A2-165,Faecalibacterium prausnitzii A2165,,core
+411489,Clostridium sp. L2-50,Clostridium sp. L250,,periphery
+411490,Anaerostipes caccae DSM14662,Anaerostipes caccae,,core
+411684,Hoeflea phototrophica DFL-43,Hoeflea phototrophica,,core
+411901,Bacteroides caccae ATCC43185,Bacteroides caccae,,periphery
+411902,[Clostridium] bolteae ATCC BAA-613,Clostridium bolteae,,periphery
+412419,Borrelia duttonii Ly,Borrelia duttonii,,periphery
+412597,Paracoccus sp. TRP,Paracoccus sp. TRP,,periphery
+412965,Candidatus Vesicomyosocius okutanii HA,Vesicomyosocius okutanii,,periphery
+413404,Candidatus Ruthia magnifica str. Cm (Calyptogena magnifica),Ruthia magnifica,,core
+413816,Halorubrum halophilum,Halorubrum halophilum,,periphery
+414684,Rhodospirillum centenum SW,Rhodospirillum centenum,,periphery
+414996,Actinopolyspora erythraea,Actinopolyspora erythraea,,core
+415426,Hyperthermus butylicus DSM5456,Hyperthermus butylicus,,periphery
+416269,Actinobacillus pleuropneumoniae serovar 5b str. L20,Actinobacillus pleuropneumoniae 5b L20,,core
+416348,Halorubrum lacusprofundi ATCC49239,Halorubrum lacusprofundi,,core
+416591,Thermotoga lettingae TMO,Thermotoga lettingae,,core
+416870,Lactococcus lactis subsp. cremoris MG1363,Lactococcus lactis cremoris,,core
+419610,Methylobacterium extorquens PA1,Methylobacterium extorquens PA1,,core
+419665,Methanococcus aeolicus Nankai-3,Methanococcus aeolicus,,core
+419947,Mycobacterium tuberculosis H37Ra,Mycobacterium tuberculosis H37Ra,,periphery
+420246,Geobacillus thermodenitrificans NG80-2,Geobacillus thermodenitrificans,,core
+420247,Methanobrevibacter smithii ATCC35061,Methanobrevibacter smithii ATCC35061,,periphery
+420324,Microvirga lupini,Microvirga lupini,,core
+420662,Methylibium petroleiphilum PM1,Methylibium petroleiphilum,,core
+420890,Lactococcus garvieae Lg2,Lactococcus garvieae Lg2,,periphery
+421052,Acinetobacter rudis CIP 110305,Acinetobacter rudis,,periphery
+421072,Epilithonimonas lactis,Epilithonimonas lactis,,core
+421531,Chryseobacterium luteum,Chryseobacterium luteum,,core
+425104,Shewanella sediminis HAW-EB3,Shewanella sediminis,,periphery
+425400,Helicobacter sp. MIT 01-6451,Helicobacter sp. MIT016451,,periphery
+426114,Thiomonas arsenitoxydans,Thiomonas arsenitoxydans,,periphery
+426117,Methylobacterium sp. 4-46,Methylobacterium sp. 446,,core
+426355,Methylobacterium radiotolerans JCM 2831,Methylobacterium radiotolerans,,periphery
+426368,Methanococcus maripaludis C7,Methanococcus maripaludis C7,,core
+426716,Nocardia rhamnosiphila,Nocardia rhamnosiphila,,periphery
+428125,[Clostridium] leptum DSM753,Clostridium leptum,,core
+428126,[Clostridium] spiroforme DSM1552,Clostridium spiroforme,,core
+428127,[Eubacterium] dolichum DSM3991,Eubacterium dolichum,,core
+429009,Ammonifex degensii KC4,Ammonifex degensii,,periphery
+430498,Dactylellina haptotyla,Dactylellina haptotyla,,core
+430998,Baudoinia compniacensis,Baudoinia compniacensis,,periphery
+431943,Clostridium kluyveri DSM555,Clostridium kluyveri,,periphery
+431947,Porphyromonas gingivalis ATCC33277,Porphyromonas gingivalis ATCC33277,,core
+432096,Kazachstania africana,Kazachstania africana,,core
+434131,Neorickettsia risticii str. Illinois,Neorickettsia risticii,,core
+435590,Bacteroides vulgatus ATCC8482,Bacteroides vulgatus,,periphery
+435591,Parabacteroides distasonis ATCC8503,Parabacteroides distasonis,,periphery
+435830,Actinomyces graevenitzii C83,Actinomyces graevenitzii,,periphery
+435832,Neisseria mucosa C102,Neisseria mucosa C102,,core
+435837,Staphylococcus hominis subsp. hominis C80,Staphylococcus hominis C80,,periphery
+435838,Staphylococcus capitis C87,Staphylococcus capitis,,periphery
+435842,Streptococcus sp. C150,Streptococcus sp. C150,,periphery
+435908,Idiomarina salinarum,Idiomarina salinarum,,core
+436114,Sulfurihydrogenibium sp. YO3AOP1,Sulfurihydrogenibium sp. YO3AOP1,,periphery
+436229,Streptacidiphilus jeojiense,Streptacidiphilus jeojiense,,periphery
+436308,Nitrosopumilus maritimus SCM1,Nitrosopumilus maritimus,,core
+436717,Acinetobacter oleivorans DR1,Acinetobacter oleivorans,,core
+438753,Azorhizobium caulinodans ORS 571,Azorhizobium caulinodans,,core
+439235,Desulfatibacillum alkenivorans AK-01,Desulfatibacillum alkenivorans,,core
+439292,[Bacillus] selenitireducens MLS10,Bacillus selenitireducens,,core
+439375,Ochrobactrum anthropi ATCC49188,Ochrobactrum anthropi,,periphery
+439481,Aciduliprofundum boonei T469,Aciduliprofundum boonei,,core
+439493,Candidatus Pelagibacter sp. HTCC7211,Pelagibacter sp. HTCC7211,,core
+439496,Rhodobacterales bacterium Y4I,Rhodobacterales bacterium Y4I,,core
+439497,Ruegeria sp. R11,Ruegeria sp. R11,,periphery
+440512,Pseudomonas sp. Chol1,Pseudomonas sp. Chol1,,periphery
+441620,Methylobacterium populi BJ001,Methylobacterium populi,,periphery
+441768,Acholeplasma laidlawii PG-8A,Acholeplasma laidlawii,,core
+441769,Bacillus coahuilensis m4-4,Bacillus coahuilensis,,core
+443143,Geobacter sp. M18,Geobacter sp. M18,,periphery
+443144,Geobacter sp. M21,Geobacter sp. M21,,periphery
+443152,Marinobacter algicola DG893,Marinobacter algicola,,periphery
+443218,Amycolicicoccus subflavus DQS3-9A1,Amycolicicoccus subflavus,,core
+443254,Marinitoga piezophila KA3,Marinitoga piezophila,,core
+443255,Streptomyces clavuligerus ATCC27064,Streptomyces clavuligerus,,core
+443598,Bradyrhizobium sp. Cp5.3,Bradyrhizobium sp. Cp53,,periphery
+443906,Clavibacter michiganensis subsp. michiganensis NCPPB 382,Clavibacter michiganensis NCPPB382,,core
+444157,Pyrobaculum neutrophilum V24Sta,Pyrobaculum neutrophilum,,periphery
+444158,Methanococcus maripaludis C6,Methanococcus maripaludis C6,,core
+445335,Clostridium botulinum NCTC2916,Clostridium botulinum NCTC2916,,periphery
+445961,Chryseobacterium soli,Chryseobacterium soli,,core
+445970,Alistipes putredinis DSM17216,Alistipes putredinis,,periphery
+445971,Anaerofustis stercorihominis DSM17244,Anaerofustis stercorihominis,,core
+445972,Anaerotruncus colihominis DSM17241,Anaerotruncus colihominis,,core
+445973,Intestinibacter bartlettii DSM16795,Intestinibacter bartlettii,,core
+445974,Erysipelatoclostridium ramosum DSM1402,Erysipelatoclostridium ramosum,,periphery
+445975,Collinsella stercoris DSM13279,Collinsella stercoris,,periphery
+445987,Borrelia valaisiana VS116,Borrelia valaisiana VS116,,core
+446462,Actinosynnema mirum DSM43827,Actinosynnema mirum,,core
+446465,Brachybacterium faecium DSM4810,Brachybacterium faecium,,core
+446466,Cellulomonas flavigena DSM20109,Cellulomonas flavigena,,periphery
+446468,Nocardiopsis dassonvillei subsp. dassonvillei DSM43111,Nocardiopsis dassonvillei,,core
+446469,Sanguibacter keddieii DSM10542,Sanguibacter keddieii,,core
+446470,Stackebrandtia nassauensis DSM44728,Stackebrandtia nassauensis,,core
+446471,Xylanimonas cellulosilytica DSM15894,Xylanimonas cellulosilytica,,core
+448385,Sorangium cellulosum So ce56,Sorangium cellulosum So ce56,,periphery
+449447,Microcystis aeruginosa NIES-843,Microcystis aeruginosa,,core
+449673,Bacteroides stercoris ATCC43183,Bacteroides stercoris,,periphery
+450380,Microbacterium profundi,Microbacterium profundi,,periphery
+450851,Phenylobacterium zucineum HLK1,Phenylobacterium zucineum,,core
+452471,Candidatus Amoebophilus asiaticus 5a2,Amoebophilus asiaticus,,core
+452637,Opitutus terrae PB90-1,Opitutus terrae,,core
+452638,Polynucleobacter necessarius subsp. necessarius STIR1,Polynucleobacter necessarius STIR1,,periphery
+452652,Kitasatospora setae KM-6054,Kitasatospora setae,,core
+452659,Rickettsia rickettsii str. Iowa,Rickettsia rickettsii,,periphery
+452662,Sphingobium japonicum UT26S,Sphingobium japonicum UT26S,,periphery
+452863,Arthrobacter chlorophenolicus A6,Arthrobacter chlorophenolicus,,core
+453591,Ignicoccus hospitalis KIN4/I,Ignicoccus hospitalis,,core
+454957,Xanthomonas arboricola pv. celebensis,Xanthomonas arboricola,,periphery
+455436,Glaciecola sp. HTCC2999,Glaciecola sp. HTCC2999,,periphery
+455632,Streptomyces griseus subsp. griseus NBRC 13350,Streptomyces griseus,,core
+456320,Methanococcus voltae A3,Methanococcus voltae,,core
+456442,Methanoregula boonei 6A8,Methanoregula boonei,,periphery
+457396,Clostridium sp. 7_2_43FAA,Clostridium sp. 7243FAA,,periphery
+457398,Desulfovibrio sp. 3_1_syn3,Desulfovibrio sp. 31syn3,,periphery
+457405,Fusobacterium nucleatum subsp. animalis 7_1,Fusobacterium nucleatum animalis,,periphery
+457412,Ruminococcus sp. 5_1_39BFAA,Ruminococcus sp. 5139BFAA,,core
+457415,Synergistes sp. 3_1_syn1,Synergistes sp. 31syn1,,core
+457421,Clostridiales bacterium 1_7_47FAA,Clostridiales bacterium 1747FAA,,periphery
+457424,Bacteroides fragilis 3_1_12,Bacteroides fragilis 3112,,periphery
+457425,Streptomyces albus J1074,Streptomyces albus J1074,,periphery
+457429,Streptomyces pristinaespiralis ATCC25486,Streptomyces pristinaespiralis,,periphery
+457570,Natranaerobius thermophilus JW/NM-WN-LF,Natranaerobius thermophilus,,core
+458233,Macrococcus caseolyticus JCSC5402,Macrococcus caseolyticus,,core
+458817,Shewanella halifaxensis HAW-EB4,Shewanella halifaxensis,,core
+459349,Candidatus Cloacimonas acidaminovorans str. Evry,Cloacimonas acidaminovorans,,core
+459495,Arthrospira platensis C1,Arthrospira platensis C1,,periphery
+460265,Methylobacterium nodulans ORS 2060,Methylobacterium nodulans,,periphery
+463191,Streptomyces sviceus ATCC29083,Streptomyces sviceus,,periphery
+465515,Micrococcus luteus NCTC 2665,Micrococcus luteus NCTC 2665,,core
+465541,Streptomyces sp. Mg1,Streptomyces sp. Mg1,,periphery
+465817,Erwinia tasmaniensis Et1/99,Erwinia tasmaniensis,,core
+466038,Candidatus Pelagibacter ubique HTCC8051,Pelagibacter ubique HTCC8051,,periphery
+466088,Acinetobacter sp. Ver3,Acinetobacter sp. Ver3,,periphery
+467200,Streptomyces griseoflavus Tu4000,Streptomyces griseoflavus,,periphery
+467661,Rhodobacteraceae bacterium KLH11,Rhodobacteraceae bacterium KLH11,,core
+467705,Streptococcus gordonii str. Challis substr. CH1,Streptococcus gordonii,,periphery
+468059,Pedobacter oryzae DSM19973,Pedobacter oryzae,,periphery
+468556,Gordonia kroppenstedtii DSM45133,Gordonia kroppenstedtii,,periphery
+469008,Escherichia coli BL21(DE3),Escherichia coli BL21,,periphery
+469371,Thermobispora bispora DSM43833,Thermobispora bispora,,periphery
+469378,Cryptobacterium curtum DSM15641,Cryptobacterium curtum,,core
+469381,Dethiosulfovibrio peptidovorans DSM11002,Dethiosulfovibrio peptidovorans,,core
+469382,Halogeometricum borinquense DSM11551,Halogeometricum borinquense,,periphery
+469383,Conexibacter woesei DSM14684,Conexibacter woesei DSM14684,,core
+469595,Citrobacter sp. 30_2,Citrobacter sp. 302,,periphery
+469596,Coprobacillus sp. 29_1,Coprobacillus sp. 291,,core
+469604,Fusobacterium nucleatum subsp. vincentii 3_1_36A2,Fusobacterium nucleatum vincentii 3136A2,,periphery
+469606,Fusobacterium nucleatum subsp. vincentii 4_1_13,Fusobacterium nucleatum vincentii 4113,,periphery
+469609,Streptococcus sp. 2_1_36FAA,Streptococcus sp. 2136FAA,,periphery
+469610,Burkholderiales bacterium 1_1_47,Burkholderiales bacterium 1147,,periphery
+469615,Fusobacterium gonidiaformans ATCC25563,Fusobacterium gonidiaformans,,core
+469616,Fusobacterium mortiferum ATCC9817,Fusobacterium mortiferum,,core
+469617,Fusobacterium ulcerans ATCC49185,Fusobacterium ulcerans,,core
+469618,Fusobacterium varium ATCC27725,Fusobacterium varium,,core
+470145,Bacteroides coprocola DSM17136,Bacteroides coprocola,,periphery
+470704,Cladophialophora yegresii,Cladophialophora yegresii,,periphery
+471223,Geobacillus sp. WCH70,Geobacillus sp. WCH70,,core
+471852,Thermomonospora curvata DSM43183,Thermomonospora curvata,,periphery
+471853,Beutenbergia cavernae DSM12333,Beutenbergia cavernae,,core
+471854,Dyadobacter fermentans DSM18053,Dyadobacter fermentans,,core
+471855,Slackia heliotrinireducens DSM20476,Slackia heliotrinireducens,,core
+471856,Jonesia denitrificans DSM20603,Jonesia denitrificans,,core
+471857,Saccharomonospora viridis DSM43017,Saccharomonospora viridis,,periphery
+471870,Bacteroides intestinalis DSM17393,Bacteroides intestinalis,,periphery
+471874,Providencia stuartii ATCC25827,Providencia stuartii,,core
+471875,Ruminococcus lactaris ATCC29176,Ruminococcus lactaris,,periphery
+471881,Proteus penneri ATCC35198,Proteus penneri,,periphery
+472175,Nitratireductor basaltis,Nitratireductor basaltis,,periphery
+472759,Nitrosococcus halophilus Nc 4,Nitrosococcus halophilus,,periphery
+474922,Colletotrichum gloeosporioides,Colletotrichum gloeosporioides,,periphery
+476272,Blautia hydrogenotrophica DSM10507,Blautia hydrogenotrophica,,core
+477184,Achromobacter arsenitoxydans SY8,Achromobacter arsenitoxydans,,periphery
+477228,Pseudomonas stutzeri TS44,Pseudomonas stutzeri TS44,,periphery
+477641,Modestobacter marinus,Modestobacter marinus,,periphery
+477974,Candidatus Desulforudis audaxviator MP104C,Desulforudis audaxviator,,core
+478741,Verrucomicrobia bacterium LP2A,Verrucomicrobia bacterium LP2A,,periphery
+478749,Marvinbryantia formatexigens DSM14469,Marvinbryantia formatexigens,,core
+478801,Kytococcus sedentarius DSM20547,Kytococcus sedentarius,,core
+479431,Nakamurella multipartita DSM44233,Nakamurella multipartita,,core
+479432,Streptosporangium roseum DSM43021,Streptosporangium roseum,,core
+479433,Catenulispora acidiphila DSM44928,Catenulispora acidiphila,,core
+479434,Sphaerobacter thermophilus DSM20745,Sphaerobacter thermophilus,,core
+479435,Kribbella flavida DSM17836,Kribbella flavida,,core
+479436,Veillonella parvula DSM2008,Veillonella parvula,,periphery
+479437,Eggerthella lenta DSM2243,Eggerthella lenta,,periphery
+481448,Methylacidiphilum infernorum V4,Methylacidiphilum infernorum,,core
+481805,Escherichia coli ATCC8739,Escherichia coli ATCC8739,,periphery
+482234,Streptococcus canis FSL Z3-227,Streptococcus canis,,periphery
+482537,Galeopterus variegatus,Galeopterus variegatus,,periphery
+483215,Bacteroides finegoldii DSM17565,Bacteroides finegoldii,,periphery
+483216,Bacteroides eggerthii DSM20697,Bacteroides eggerthii,,core
+483218,[Bacteroides] pectinophilus ATCC43243,Bacteroides pectinophilus,,core
+483219,Myxococcus fulvus HW-1,Myxococcus fulvus,,periphery
+484018,Bacteroides plebeius DSM17135,Bacteroides plebeius,,periphery
+484019,Thermosipho africanus TCF52B,Thermosipho africanus,,core
+484022,Francisella philomiragia subsp. philomiragia ATCC25017,Francisella philomiragia,,periphery
+484770,Pelosinus sp. UFO1,Pelosinus sp. UFO1,,core
+485913,Ktedonobacter racemifer DSM44963,Ktedonobacter racemifer,,core
+485914,Halomicrobium mukohataei DSM12286,Halomicrobium mukohataei,,core
+485915,Desulfohalobium retbaense DSM5692,Desulfohalobium retbaense,,core
+485916,Desulfotomaculum acetoxidans DSM771,Desulfotomaculum acetoxidans,,periphery
+485917,Pedobacter heparinus DSM2366,Pedobacter heparinus,,core
+485918,Chitinophaga pinensis DSM2588,Chitinophaga pinensis,,core
+487316,Acinetobacter soli,Acinetobacter soli,,periphery
+487521,Mycobacterium intracellulare ATCC13950,Mycobacterium intracellulare,,periphery
+487796,Flavobacteria bacterium MS024-2A,Flavobacteria bacterium MS0242A,,core
+488538,Candidatus Puniceispirillum marinum IMCC1322,Puniceispirillum marinum,,core
+489653,Neisseria lactamica 020-06,Neisseria lactamica,,periphery
+489825,Moorea producens 3L,Moorea producens,,core
+490899,Desulfurococcus kamchatkensis 1221n,Desulfurococcus kamchatkensis,,periphery
+491205,Chryseobacterium hispalense DSM25574,Chryseobacterium hispalense,,periphery
+491915,Anoxybacillus flavithermus WK1,Anoxybacillus flavithermus WK1,,core
+491916,Rhizobium etli CIAT 652,Rhizobium etli CIAT652,,periphery
+491952,Marinomonas posidonica IVIA-Po-181,Marinomonas posidonica,,periphery
+492774,Rhizobium alamii,Rhizobium alamii,,periphery
+493475,Glaciecola arctica BSs20135,Glaciecola arctica,,periphery
+494416,Psychrobacter sp. TB15,Psychrobacter sp. TB15,,periphery
+494419,Arthrobacter sp. TB 23,Arthrobacter sp. TB23,,periphery
+496833,Mycoplasma fermentans PG18,Mycoplasma fermentans,,periphery
+497321,Thauera sp. 63,Thauera sp. 63,,periphery
+497964,Chthoniobacter flavus Ellin428,Chthoniobacter flavus,,core
+497965,Cyanothece sp. PCC7822,Cyanothece sp. PCC7822,,periphery
+498211,Cellvibrio japonicus Ueda107,Cellvibrio japonicus,,core
+498742,Borrelia spielmanii A14S,Borrelia spielmanii,,core
+498761,Heliobacterium modesticaldum Ice1,Heliobacterium modesticaldum,,core
+498848,Thermus aquaticus Y51MC23,Thermus aquaticus,,core
+500153,Streptomyces avicenniae,Streptomyces avicenniae,,periphery
+500632,Tyzzerella nexilis DSM1787,Tyzzerella nexilis,,core
+500633,[Clostridium] hiranonis DSM13275,Clostridium hiranonis,,periphery
+500635,Mitsuokella multacida DSM20544,Mitsuokella multacida,,core
+500637,Providencia rustigianii DSM4541,Providencia rustigianii,,core
+500640,Citrobacter youngae ATCC29220,Citrobacter youngae,,periphery
+501479,Citreicella sp. SE45,Citreicella sp. SE45,,core
+502025,Haliangium ochraceum DSM14365,Haliangium ochraceum,,core
+502347,Escherichia albertii TW07627,Escherichia albertii TW07627,,core
+502558,Eggerthella sp. YY7918,Eggerthella sp. YY7918,,periphery
+504472,Spirosoma linguale DSM74,Spirosoma linguale,,core
+504474,Corynebacterium urealyticum DSM7109,Corynebacterium urealyticum,,periphery
+504487,Jejuia pallidilutea,Jejuia pallidilutea,,core
+504728,Meiothermus ruber DSM1279,Meiothermus ruber,,core
+504832,Oligotropha carboxidovorans OM5,Oligotropha carboxidovorans,,core
+506534,Rheinheimera sp. A13L,Rheinheimera sp. A13L,,core
+509190,Caulobacter segnis ATCC21756,Caulobacter segnis,,periphery
+509191,Acetivibrio cellulolyticus CD2,Acetivibrio cellulolyticus,,core
+509635,Pedobacter sp. V48,Pedobacter sp. V48,,periphery
+511051,Caldisericum exile AZM16c01,Caldisericum exile,,core
+511062,Oceanimonas sp. GK1,Oceanimonas sp. GK1,,core
+511145,Escherichia coli str. K-12 substr. MG1655,Escherichia coli K12 MG1655,,core
+511437,Lactobacillus buchneri NRRL B-30929,Lactobacillus buchneri NRRLB30929,,periphery
+511680,Butyrivibrio crossotus DSM2876,Butyrivibrio crossotus,,periphery
+511995,Candidatus Azobacteroides pseudotrichonymphae genomovar. CFP2,Azobacteroides pseudotrichonymphae,,core
+512564,Mycoplasma crocodyli MP145,Mycoplasma crocodyli,,periphery
+512565,Actinoplanes missouriensis 431,Actinoplanes missouriensis,,periphery
+515618,Candidatus Riesia pediculicola USDA,Riesia pediculicola,,core
+515620,[Eubacterium] eligens ATCC27750,Eubacterium eligens,,core
+515622,Butyrivibrio proteoclasticus B316,Butyrivibrio proteoclasticus B316,,core
+515635,Dictyoglomus turgidum DSM6724,Dictyoglomus turgidum,,periphery
+517417,Chlorobaculum parvum NCIB 8327,Chlorobaculum parvum,,periphery
+517418,Chloroherpeton thalassium ATCC35110,Chloroherpeton thalassium,,core
+517433,Pantoea sp. aB,Pantoea sp. aB,,periphery
+517722,Citromicrobium sp. JLT1363,Citromicrobium sp. JLT1363,,periphery
+518635,Bifidobacterium angulatum DSM20098,Bifidobacterium angulatum,,periphery
+518637,Holdemanella biformis DSM3989,Holdemanella biformis,,core
+518766,Rhodothermus marinus DSM4252,Rhodothermus marinus,,core
+519441,Streptobacillus moniliformis DSM12112,Streptobacillus moniliformis,,core
+519442,Halorhabdus utahensis DSM12940,Halorhabdus utahensis,,core
+519989,Ectothiorhodospira sp. PHS-1,Ectothiorhodospira sp. PHS1,,periphery
+520709,Acinetobacter sp. NIPH 973,Acinetobacter sp. NIPH973,,periphery
+520999,Providencia alcalifaciens DSM30120,Providencia alcalifaciens,,periphery
+521000,Providencia rettgeri DSM1131,Providencia rettgeri DSM1131,,periphery
+521003,Collinsella intestinalis DSM13280,Collinsella intestinalis,,core
+521010,Borrelia bissettii DN127,Borrelia bissettii,,periphery
+521011,Methanosphaerula palustris E1-9c,Methanosphaerula palustris,,core
+521045,Kosmotoga olearia TBF 19.5.1,Kosmotoga olearia,,core
+521095,Atopobium parvulum DSM20469,Atopobium parvulum,,periphery
+521096,Tsukamurella paurometabola DSM20162,Tsukamurella paurometabola,,periphery
+521097,Capnocytophaga ochracea DSM7271,Capnocytophaga ochracea DSM7271,,core
+521098,Alicyclobacillus acidocaldarius subsp. acidocaldarius DSM446,Alicyclobacillus acidocaldarius DSM446,,core
+521393,Actinomyces timonensis DSM23838,Actinomyces timonensis,,periphery
+521460,Caldicellulosiruptor bescii DSM6725,Caldicellulosiruptor bescii,,core
+521674,Planctomyces limnophilus DSM3776,Planctomyces limnophilus,,periphery
+521719,Pseudomonas caeni DSM24390,Pseudomonas caeni,,periphery
+522306,Candidatus Accumulibacter phosphatis clade IIA str. UW-1,Accumulibacter phosphatis,,core
+522373,Stenotrophomonas maltophilia K279a,Stenotrophomonas maltophilia K279a,,core
+522772,Denitrovibrio acetiphilus DSM12809,Denitrovibrio acetiphilus,,core
+523791,Kangiella koreensis DSM16069,Kangiella koreensis,,core
+523794,Leptotrichia buccalis C-1013-b,Leptotrichia buccalis,,core
+523841,Haloferax mediterranei ATCC33500,Haloferax mediterranei,,periphery
+523845,Methanothermococcus thermolithotrophicus DSM2095,Methanothermococcus thermolithotrophicus,,periphery
+523850,Thermococcus onnurineus NA1,Thermococcus onnurineus,,core
+525146,Desulfovibrio desulfuricans subsp. desulfuricans str. ATCC27774,Desulfovibrio desulfuricans ATCC27774,,core
+525244,Acinetobacter sp. ATCC27244,Acinetobacter sp. ATCC27244,,periphery
+525245,Actinomyces coleocanis DSM15436,Actinomyces coleocanis,,periphery
+525246,Actinomyces urogenitalis DSM15434,Actinomyces urogenitalis DSM15434,,periphery
+525254,Anaerococcus lactolyticus ATCC51172,Anaerococcus lactolyticus ATCC51172,,periphery
+525255,Anaerococcus tetradius ATCC35098,Anaerococcus tetradius,,periphery
+525256,Atopobium vaginae DSM15829,Atopobium vaginae DSM15829,,periphery
+525257,Chryseobacterium gleum ATCC35910,Chryseobacterium gleum,,core
+525260,Corynebacterium accolens ATCC49725,Corynebacterium accolens,,periphery
+525263,Corynebacterium lipophiloflavum DSM44291,Corynebacterium lipophiloflavum,,periphery
+525264,Corynebacterium pseudogenitalium ATCC33035,Corynebacterium pseudogenitalium,,periphery
+525268,Corynebacterium striatum ATCC6940,Corynebacterium striatum,,periphery
+525282,Finegoldia magna ATCC53516,Finegoldia magna ATCC53516,,periphery
+525309,Lactobacillus antri DSM16041,Lactobacillus antri,,periphery
+525318,Lactobacillus buchneri ATCC11577,Lactobacillus buchneri ATCC11577,,periphery
+525365,Lactobacillus ultunensis DSM16047,Lactobacillus ultunensis,,periphery
+525367,Listeria grayi DSM20601,Listeria grayi,,periphery
+525368,Mycobacterium parascrofulaceum ATCC BAA-614,Mycobacterium parascrofulaceum,,periphery
+525373,Sphingobacterium spiritivorum ATCC33861,Sphingobacterium spiritivorum,,core
+525378,Staphylococcus caprae M23864:W1,Staphylococcus caprae,,periphery
+525379,Streptococcus equinus ATCC9812,Streptococcus equinus,,periphery
+525897,Desulfomicrobium baculatum DSM4028,Desulfomicrobium baculatum,,core
+525898,Sulfurospirillum deleyianum DSM6946,Sulfurospirillum deleyianum,,periphery
+525903,Thermanaerovibrio acidaminovorans DSM6589,Thermanaerovibrio acidaminovorans,,core
+525904,Thermobaculum terrenum ATCC BAA-798,Thermobaculum terrenum,,core
+525909,Acidimicrobium ferrooxidans DSM10331,Acidimicrobium ferrooxidans,,core
+525919,Anaerococcus prevotii DSM20548,Anaerococcus prevotii DSM20548,,core
+526218,Sebaldella termitidis ATCC33386,Sebaldella termitidis,,core
+526222,Desulfovibrio salexigens DSM2638,Desulfovibrio salexigens,,periphery
+526224,Brachyspira murdochii DSM12563,Brachyspira murdochii,,periphery
+526225,Geodermatophilus obscurus DSM43160,Geodermatophilus obscurus,,core
+526226,Gordonia bronchialis DSM43247,Gordonia bronchialis,,periphery
+526227,Meiothermus silvanus DSM9946,Meiothermus silvanus,,periphery
+527002,Yersinia aldovae ATCC35236,Yersinia aldovae,,periphery
+529507,Proteus mirabilis HI4320,Proteus mirabilis,,periphery
+529709,Pyrococcus yayanosii CH1,Pyrococcus yayanosii,,periphery
+529818,Thecamonas trahens,Thecamonas trahens,,core
+529884,Candidatus Rhodoluna lacicola,Rhodoluna lacicola,,periphery
+530564,Pirellula staleyi DSM6068,Pirellula staleyi,,core
+531844,Flavobacteriaceae bacterium 3519-10,Flavobacteriaceae bacterium 351910,,periphery
+533240,Cylindrospermopsis raciborskii CS-505,Cylindrospermopsis raciborskii,,core
+533247,Raphidiopsis brookii D9,Raphidiopsis brookii,,core
+535289,Acidovorax ebreus TPSY,Acidovorax ebreus,,core
+536019,Mesorhizobium opportunistum WSM2075,Mesorhizobium opportunistum,,periphery
+536227,Clostridium carboxidivorans P7,Clostridium carboxidivorans,,periphery
+536232,Clostridium botulinum A2 str. Kyoto,Clostridium botulinum A2 Kyoto,,periphery
+536233,Clostridium botulinum E1 str. 'BoNT E Beluga',Clostridium botulinum E1 BoNT,,periphery
+537007,Blautia hansenii DSM20583,Blautia hansenii,,periphery
+537011,Prevotella copri DSM18205,Prevotella copri,,periphery
+537013,[Clostridium] methylpentosum DSM5476,Clostridium methylpentosum,,periphery
+537021,Candidatus Liberibacter asiaticus str. psy62,Liberibacter asiaticus psy62,,periphery
+537970,Helicobacter canadensis MIT 98-5491,Helicobacter canadensis,,periphery
+537971,Helicobacter cinaedi CCUG18818,Helicobacter cinaedi CCUG18818,,periphery
+537972,Helicobacter pullorum MIT 98-5489,Helicobacter pullorum,,periphery
+543526,Haloterrigena turkmenica DSM5511,Haloterrigena turkmenica,,periphery
+543632,Actinoplanes subtropicus,Actinoplanes subtropicus,,periphery
+543728,Variovorax paradoxus S110,Variovorax paradoxus S110,,periphery
+543734,Lactobacillus casei BL23,Lactobacillus casei BL23,,core
+543913,beta proteobacterium CB,beta proteobacterium CB,,core
+545243,Clostridium arbusti SL206,Clostridium arbusti,,periphery
+545264,Thioalkalivibrio sp. AKL11,Thioalkalivibrio sp. AKL11,,periphery
+545276,Thioalkalivibrio sp. ALJ24,Thioalkalivibrio sp. ALJ24,,periphery
+545693,Bacillus megaterium QM B1551,Bacillus megaterium QM B1551,,core
+545694,Treponema primitia ZAS-2,Treponema primitia ZAS2,,periphery
+545695,Treponema azotonutricium ZAS-9,Treponema azotonutricium,,periphery
+545696,Holdemania filiformis DSM12042,Holdemania filiformis,,core
+545697,Clostridium celatum DSM1785,Clostridium celatum,,periphery
+546262,Neisseria cinerea ATCC14685,Neisseria cinerea,,core
+546264,Neisseria flavescens NRL30031/H210,Neisseria flavescens NRL30031H210,,core
+546266,Neisseria mucosa ATCC25996,Neisseria mucosa ATCC25996,,periphery
+546267,Neisseria polysaccharea ATCC43768,Neisseria polysaccharea,,periphery
+546268,Neisseria subflava NJ9703,Neisseria subflava,,periphery
+546269,Filifactor alocis ATCC35896,Filifactor alocis,,core
+546270,Gemella haemolysans ATCC10379,Gemella haemolysans ATCC10379,,periphery
+546271,Selenomonas sputigena ATCC35185,Selenomonas sputigena,,periphery
+546273,Veillonella dispar ATCC17748,Veillonella dispar,,core
+546274,Eikenella corrodens ATCC23834,Eikenella corrodens ATCC23834,,core
+546275,Fusobacterium periodonticum ATCC33693,Fusobacterium periodonticum,,core
+546414,Deinococcus deserti VCD115,Deinococcus deserti,,periphery
+547042,Bacteroides coprophilus DSM18228,Bacteroides coprophilus,,periphery
+547043,Bifidobacterium pseudocatenulatum DSM20438,Bifidobacterium pseudocatenulatum,,periphery
+547045,Neisseria sicca ATCC29256,Neisseria sicca,,periphery
+547144,Hydrogenobaculum sp. HO,Hydrogenobaculum sp. HO,,periphery
+547163,Mycobacterium vulneris,Mycobacterium vulneris,,periphery
+547559,Natrialba magadii ATCC43099,Natrialba magadii,,core
+548476,Corynebacterium aurimucosum ATCC700975,Corynebacterium aurimucosum,,periphery
+548477,Corynebacterium glucuronolyticum ATCC51867,Corynebacterium glucuronolyticum,,periphery
+548479,Mobiluncus curtisii ATCC43063,Mobiluncus curtisii ATCC43063,,periphery
+550540,Ferrimonas balearica DSM9799,Ferrimonas balearica,,core
+551115,'Nostoc azollae' 0708,Nostoc azollae,,periphery
+551275,Hirschia maritima DSM19733,Hirschia maritima,,periphery
+551789,Ponticaulis koreensis DSM19734,Ponticaulis koreensis,,periphery
+552396,Erysipelotrichaceae bacterium 5_2_54FAA,Erysipelotrichaceae bacterium 5254FAA,,periphery
+552398,Ruminococcaceae bacterium D16,Ruminococcaceae bacterium D16,,periphery
+552467,Cryptococcus gattii,Cryptococcus gattii,,periphery
+552531,Bifidobacterium animalis subsp. lactis BB-12,Bifidobacterium animalis,,periphery
+552811,Dehalogenimonas lykanthroporepellens BL-DC-9,Dehalogenimonas lykanthroporepellens,,core
+553171,Prevotella bivia JCVIHMP010,Prevotella bivia JCVIHMP010,,periphery
+553174,Prevotella melaninogenica ATCC25845,Prevotella melaninogenica,,periphery
+553175,Porphyromonas endodontalis ATCC35406,Porphyromonas endodontalis,,periphery
+553177,Capnocytophaga sputigena ATCC33612,Capnocytophaga sputigena,,core
+553178,Capnocytophaga gingivalis ATCC33624,Capnocytophaga gingivalis,,periphery
+553184,Atopobium rimae ATCC49626,Atopobium rimae,,periphery
+553204,Corynebacterium amycolatum SK46,Corynebacterium amycolatum,,periphery
+553207,Corynebacterium matruchotii ATCC14266,Corynebacterium matruchotii,,periphery
+553217,Enhydrobacter aerosaccus SK60,Enhydrobacter aerosaccus,,core
+553218,Campylobacter rectus RM3267,Campylobacter rectus,,periphery
+553219,Campylobacter showae RM3277,Campylobacter showae RM3277,,periphery
+553220,Campylobacter gracilis RM3268,Campylobacter gracilis,,periphery
+553385,Cobetia crustatorum,Cobetia crustatorum,,periphery
+553973,[Clostridium] hylemonae DSM15053,Clostridium hylemonae,,periphery
+554065,Chlorella variabilis,Chlorella variabilis,,core
+555079,Thermosediminibacter oceani DSM16646,Thermosediminibacter oceani,,core
+555088,Dethiobacter alkaliphilus AHT 1,Dethiobacter alkaliphilus,,periphery
+555217,Zymomonas mobilis subsp. mobilis ATCC10988,Zymomonas mobilis ATCC10988,,core
+555500,Galbibacter marinus,Galbibacter marinus,,core
+555778,Halothiobacillus neapolitanus c2,Halothiobacillus neapolitanus,,core
+555779,Desulfonatronospira thiodismutans ASO3-1,Desulfonatronospira thiodismutans,,core
+555793,Novosphingobium sp. Rr 2-17,Novosphingobium sp. Rr 217,,periphery
+556261,Clostridium sp. D5,Clostridium sp. D5,,periphery
+556263,Fusobacterium necrophorum D12,Fusobacterium necrophorum D12,,core
+556267,Helicobacter winghamensis ATCC BAA-430,Helicobacter winghamensis,,periphery
+556268,Oxalobacter formigenes HOxBLS,Oxalobacter formigenes HOxBLS,,periphery
+556269,Oxalobacter formigenes OXCC13,Oxalobacter formigenes OXCC13,,periphery
+557436,Lactobacillus reuteri DSM20016,Lactobacillus reuteri DSM20016,,core
+557598,Laribacter hongkongensis HLHK9,Laribacter hongkongensis,,core
+557599,Mycobacterium kansasii ATCC12478,Mycobacterium kansasii ATCC12478,,periphery
+558152,Chryseobacterium piperi,Chryseobacterium piperi,,periphery
+558169,Lentibacillus jeotgali,Lentibacillus jeotgali,,core
+558173,Corynebacterium doosanense CAU212,Corynebacterium doosanense,,periphery
+558884,Aeromonas sp. AE122,Aeromonas sp. AE122,,periphery
+561175,Actinomadura flavalba DSM45200,Actinomadura flavalba,,periphery
+561177,Anaerococcus hydrogenalis DSM7454,Anaerococcus hydrogenalis,,periphery
+561180,Bifidobacterium gallicum DSM20093,Bifidobacterium gallicum,,periphery
+561229,Dickeya zeae Ech1591,Dickeya zeae,,core
+561230,Pectobacterium carotovorum subsp. carotovorum PC1,Pectobacterium carotovorum PC1,,periphery
+561231,Pectobacterium wasabiae WPP163,Pectobacterium wasabiae,,periphery
+562743,Amphibacillus jilinensis Y1,Amphibacillus jilinensis,,core
+562970,Kyrpidia tusciae DSM2912,Kyrpidia tusciae,,core
+562973,Actinomyces viscosus C505,Actinomyces viscosus,,periphery
+562981,Gemella haemolysans M341,Gemella haemolysans M341,,core
+562982,Gemella morbillorum M424,Gemella morbillorum,,core
+562983,Gemella sanguinis M325,Gemella sanguinis,,periphery
+563008,Prevotella oris C735,Prevotella oris C735,,core
+563031,Prevotella sp. C561,Prevotella sp. C561,,periphery
+563037,Streptococcus sp. M143,Streptococcus sp. M143,,periphery
+563038,Streptococcus sp. M334,Streptococcus sp. M334,,periphery
+563040,Sulfurimonas autotrophica DSM16294,Sulfurimonas autotrophica,,periphery
+563192,Bilophila wadsworthia 3_1_6,Bilophila wadsworthia 316,,core
+565033,Geoglobus acetivorans,Geoglobus acetivorans,,core
+565034,Brachyspira hyodysenteriae WA1,Brachyspira hyodysenteriae,,core
+565045,Luminiphilus syltensis NOR5-1B,Luminiphilus syltensis,,periphery
+565575,Ureaplasma urealyticum serovar 10 str. ATCC33699,Ureaplasma urealyticum,,periphery
+565653,Enterococcus gallinarum EG2,Enterococcus gallinarum,,periphery
+565655,Enterococcus casseliflavus EC20,Enterococcus casseliflavus,,core
+565664,Enterococcus faecium C68,Enterococcus faecium C68,,periphery
+566461,Streptomyces ghanaensis ATCC14672,Streptomyces ghanaensis,,periphery
+566466,gamma proteobacterium NOR5-3,Gammaproteobacteria bacterium NOR53,,periphery
+566552,Bifidobacterium catenulatum DSM16992,Bifidobacterium catenulatum,,periphery
+568076,Metarhizium robertsii,Metarhizium robertsii,,periphery
+568703,Lactobacillus rhamnosus GG,Lactobacillus rhamnosus,,core
+568706,Bordetella pertussis 18323,Bordetella pertussis 18323,,core
+568768,Dickeya sp. NCPPB 569,Dickeya sp. NCPPB569,,periphery
+568816,Acidaminococcus intestini RyC-MR95,Acidaminococcus intestini,,core
+568817,Serratia symbiotica str. 'Cinara cedri',Serratia symbiotica,,periphery
+570268,Nocardiopsis potens DSM45234,Nocardiopsis potens,,periphery
+570417,Wolbachia endosymbiont of Culex quinquefasciatus Pel,Wolbachia sp. Culex,,periphery
+570952,Fodinicurvata sediminis DSM21159,Fodinicurvata sediminis,,core
+570967,Fodinicurvata fenggangensis DSM21160,Fodinicurvata fenggangensis,,periphery
+571166,Sedimentitalea nanhaiensis DSM24252,Sedimentitalea nanhaiensis,,core
+572265,Candidatus Hamiltonella defensa 5AT (Acyrthosiphon pisum),Hamiltonella defensa,,periphery
+572477,Allochromatium vinosum DSM180,Allochromatium vinosum,,core
+572478,Vulcanisaeta distributa DSM14429,Vulcanisaeta distributa,,core
+572479,Halanaerobium praevalens DSM2228,Halanaerobium praevalens,,periphery
+572480,Arcobacter nitrofigilis DSM7299,Arcobacter nitrofigilis,,periphery
+572544,Ilyobacter polytropus DSM2926,Ilyobacter polytropus,,core
+572546,Archaeoglobus profundus DSM5631,Archaeoglobus profundus,,periphery
+572547,Aminobacterium colombiense DSM12261,Aminobacterium colombiense,,core
+573061,Clostridium cellulovorans 743B,Clostridium cellulovorans,,periphery
+573063,Methanocaldococcus infernus ME,Methanocaldococcus infernus,,periphery
+573064,Methanocaldococcus fervens AG86,Methanocaldococcus fervens,,core
+573065,Asticcacaulis excentricus CB 48,Asticcacaulis excentricus,,core
+573370,Desulfovibrio magneticus RS-1,Desulfovibrio magneticus RS1,,core
+573413,Spirochaeta smaragdinae DSM11293,Spirochaeta smaragdinae,,core
+573569,Francisella sp. TX077308,Francisella sp. TX077308,,periphery
+574087,Acetohalobium arabaticum DSM5501,Acetohalobium arabaticum,,core
+574375,Bacillus gaemokensis,Bacillus gaemokensis,,periphery
+574376,Bacillus manliponensis,Bacillus manliponensis,,periphery
+574556,Anaplasma centrale str. Israel,Anaplasma centrale,,periphery
+574966,Halomonas zhanjiangensis DSM21076,Halomonas zhanjiangensis,,periphery
+575540,Isosphaera pallida ATCC43644,Isosphaera pallida,,core
+575564,Acinetobacter sp. RUH2624,Acinetobacter sp. RUH2624,,periphery
+575586,Acinetobacter johnsonii SH046,Acinetobacter johnsonii,,periphery
+575588,Acinetobacter lwoffii SH145,Acinetobacter lwoffii SH145,,periphery
+575589,Acinetobacter radioresistens SH164,Acinetobacter radioresistens,,periphery
+575590,Bacteroidetes oral taxon 274 str. F0058,Bacteroidetes F0058,,periphery
+575593,Lachnospiraceae oral taxon 107 str. F0167,Lachnospiraceae F0167,,periphery
+575594,Lactobacillus coleohominis 101-4-CHN,Lactobacillus coleohominis,,periphery
+575605,Lactobacillus jensenii 115-3-CHN,Lactobacillus jensenii 1153CHN,,periphery
+575606,Lactobacillus jensenii 27-2-CHN,Lactobacillus jensenii 272CHN,,periphery
+575609,Peptoniphilus sp. oral taxon 386 str. F0131,Peptoniphilus sp. F0131,,periphery
+575615,Prevotella sp. oral taxon 317 str. F0108,Prevotella sp. F0108,,periphery
+575788,Vibrio tasmaniensis LGP32,Vibrio tasmaniensis,,periphery
+579137,Methanocaldococcus vulcanius M7,Methanocaldococcus vulcanius,,periphery
+579138,Zymomonas mobilis subsp. pomaceae ATCC29192,Zymomonas mobilis pomaceae,,periphery
+579405,Dickeya dadantii Ech703,Dickeya dadantii Ech703,,periphery
+580327,Thermoanaerobacterium thermosaccharolyticum DSM571,Thermoanaerobacterium thermosaccharolyticum,,periphery
+580331,Thermoanaerobacter italicus Ab9,Thermoanaerobacter italicus,,core
+580332,Sideroxydans lithotrophicus ES-1,Sideroxydans lithotrophicus,,core
+580340,Thermovirga lienii DSM17291,Thermovirga lienii,,core
+582402,Hirschia baltica ATCC49814,Hirschia baltica,,core
+582515,Rubidibacter lacunae KORDI 51-2,Rubidibacter lacunae,,core
+582744,Methylovorus glucosetrophus SIP3-4,Methylovorus glucosetrophus,,core
+582899,Hyphomicrobium denitrificans ATCC51888,Hyphomicrobium denitrificans ATCC51888,,core
+583345,Methylotenera mobilis JLW8,Methylotenera mobilis JLW8,,periphery
+583355,Coraliomargarita akajimensis DSM45221,Coraliomargarita akajimensis,,core
+584708,Aminomonas paucivorans DSM12260,Aminomonas paucivorans,,core
+585198,Mobiluncus curtisii subsp. curtisii ATCC35241,Mobiluncus curtisii ATCC35241,,periphery
+585199,Mobiluncus mulieris ATCC35243,Mobiluncus mulieris ATCC35243,,periphery
+585202,Streptococcus mitis SK321,Streptococcus mitis SK321,,periphery
+585203,Streptococcus mitis SK564,Streptococcus mitis SK564,,periphery
+585204,Streptococcus mitis SK597,Streptococcus mitis SK597,,periphery
+585394,Roseburia hominis A2-183,Roseburia hominis,,periphery
+585423,Synechococcus sp. KORDI-49,Synechococcus sp. KORDI49,,periphery
+585425,Synechococcus sp. KORDI-52,Synechococcus sp. KORDI52,,periphery
+585501,Oribacterium sinus F0268,Oribacterium sinus,,periphery
+585502,Prevotella bergensis DSM17361,Prevotella bergensis,,periphery
+585503,Selenomonas noxia ATCC43541,Selenomonas noxia ATCC43541,,periphery
+585506,Weissella paramesenteroides ATCC33313,Weissella paramesenteroides,,periphery
+585524,Lactobacillus amylolyticus DSM11664,Lactobacillus amylolyticus,,periphery
+585529,Corynebacterium genitalium ATCC33030,Corynebacterium genitalium,,periphery
+585530,Brevibacterium mcbrellneri ATCC49030,Brevibacterium mcbrellneri,,core
+585531,Aeromicrobium marinum DSM15272,Aeromicrobium marinum,,core
+585543,Bacteroides sp. D20,Bacteroides sp. D20,,core
+586413,Oceanobacillus manasiensis,Oceanobacillus manasiensis,,periphery
+586416,Terribacillus aidingensis,Terribacillus aidingensis,,core
+587753,Pseudomonas chlororaphis,Pseudomonas chlororaphis,,periphery
+588581,[Clostridium] papyrosolvens DSM2782,Clostridium papyrosolvens,,periphery
+588596,Rhizophagus irregularis,Rhizophagus irregularis,,core
+588726,Kazachstania naganishii,Kazachstania naganishii,,periphery
+588932,Brevundimonas naejangsanensis,Brevundimonas naejangsanensis,,core
+589865,Desulfurivibrio alkaliphilus AHT2,Desulfurivibrio alkaliphilus,,core
+589873,Alteromonas australica,Alteromonas australica,,core
+589924,Ferroglobus placidus DSM10642,Ferroglobus placidus,,core
+590409,Dickeya dadantii Ech586,Dickeya dadantii Ech586,,periphery
+590998,Cellulomonas fimi ATCC484,Cellulomonas fimi,,core
+591001,Acidaminococcus fermentans DSM20731,Acidaminococcus fermentans,,core
+591019,Staphylothermus hellenicus DSM12710,Staphylothermus hellenicus,,periphery
+591023,Actinobacillus minor 202,Actinobacillus minor 202,,periphery
+591157,Streptomyces sp. SPB78,Streptomyces sp. SPB78,,periphery
+591158,Streptomyces sp. AA4,Streptomyces sp. AA4,,periphery
+591159,Streptomyces viridochromogenes DSM40736,Streptomyces viridochromogenes,,periphery
+591167,Streptomyces pratensis ATCC33331,Streptomyces pratensis,,periphery
+592010,Abiotrophia defectiva ATCC49176,Abiotrophia defectiva,,core
+592015,Anaerobaculum hydrogeniformans ATCC BAA-1850,Anaerobaculum hydrogeniformans,,periphery
+592026,Catonella morbi ATCC51271,Catonella morbi,,core
+592027,Clostridium botulinum D str. 1873,Clostridium botulinum D 1873,,core
+592028,Dialister invisus DSM15470,Dialister invisus,,core
+592029,Nonlabens dokdonensis DSW-6,Nonlabens dokdonensis,,periphery
+592031,Eubacterium saphenum ATCC49989,Eubacterium saphenum,,core
+592316,Pantoea sp. At-9b,Pantoea sp. At9b,,periphery
+593105,Pantoea sp. Sc1,Pantoea sp. Sc1,,periphery
+593117,Thermococcus gammatolerans EJ3,Thermococcus gammatolerans,,core
+593750,Methanoregula formicica SMSP,Methanoregula formicica,,periphery
+593907,[Cellvibrio] gilvus ATCC13127,Cellvibrio gilvus,,periphery
+595460,Rhodopirellula sp. SWK7,Rhodopirellula sp. SWK7,,periphery
+595494,Tolumonas auensis DSM9187,Tolumonas auensis,,core
+595536,Methylosinus trichosporium OB3b,Methylosinus trichosporium,,core
+595537,Variovorax paradoxus EPS,Variovorax paradoxus EPS,,core
+595593,Arthrobacter sp. A3,Arthrobacter sp. A3,,periphery
+596151,Desulfovibrio fructosivorans JJ,Desulfovibrio fructosivorans,,periphery
+596152,Desulfovibrio sp. U5L,Desulfovibrio sp. U5L,,periphery
+596153,Alicycliphilus denitrificans BC,Alicycliphilus denitrificans BC,,periphery
+596154,Alicycliphilus denitrificans K601,Alicycliphilus denitrificans K601,,core
+596315,Peptostreptococcus stomatis DSM17678,Peptostreptococcus stomatis,,periphery
+596319,Staphylococcus warneri L37603,Staphylococcus warneri L37603,,periphery
+596320,Neisseria flavescens SK114,Neisseria flavescens SK114,,periphery
+596323,Leptotrichia goodfellowii F0264,Leptotrichia goodfellowii,,periphery
+596324,Treponema vincentii ATCC35580,Treponema vincentii,,core
+596327,Porphyromonas uenonis 60-3,Porphyromonas uenonis 603,,core
+596328,Mobiluncus mulieris 28-1,Mobiluncus mulieris 281,,core
+596329,Peptostreptococcus anaerobius 653-L,Peptostreptococcus anaerobius 653L,,core
+596330,Peptoniphilus lacrimalis 315-B,Peptoniphilus lacrimalis,,periphery
+598467,Brenneria sp. EniD312,Brenneria sp. EniD312,,core
+598659,Nautilia profundicola AmH,Nautilia profundicola,,core
+600809,Blattabacterium sp. (Periplaneta americana),Blattabacterium sp. BPLAN,,periphery
+604331,Meiothermus rufus DSM22234,Meiothermus rufus,,periphery
+604354,Thermococcus sibiricus MM 739,Thermococcus sibiricus,,periphery
+608506,Caldicellulosiruptor obsidiansis OB47,Caldicellulosiruptor obsidiansis,,periphery
+608534,Oribacterium sp. oral taxon 078 str. F0262,Oribacterium sp. F0262,,core
+608538,Hydrogenobacter thermophilus TK-6,Hydrogenobacter thermophilus,,core
+610130,[Clostridium] saccharolyticum WM1,Clostridium saccharolyticum WM1,,core
+613026,Helicobacter bilis ATCC43879,Helicobacter bilis,,periphery
+614083,Rhodoferax saidenbachensis ED16,Rhodoferax saidenbachensis,,periphery
+616991,Arenibacter algicola,Arenibacter algicola,,core
+617140,Vibrio splendidus ZS-139,Vibrio splendidus,,periphery
+619693,Prevotella sp. oral taxon 472 str. F0295,Prevotella sp. F0295,,periphery
+620914,Aquimarina agarilytica ZC1,Aquimarina agarilytica,,periphery
+621372,Paenibacillus sp. oral taxon 786 str. D14,Paenibacillus sp. D14,,core
+622312,Roseburia inulinivorans DSM16841,Roseburia inulinivorans,,core
+622637,Methylocystis sp. ATCC49242,Methylocystis sp. ATCC49242,,core
+626369,Granulicatella elegans ATCC700633,Granulicatella elegans,,periphery
+626418,Burkholderia glumae BGR1,Burkholderia glumae,,periphery
+626522,Prevotella tannerae ATCC51259,Prevotella tannerae,,core
+626523,Shuttleworthia satelles DSM14600,Shuttleworthia satelles,,core
+626887,Marinobacter nanhaiticus D15-8W,Marinobacter nanhaiticus,,periphery
+626939,Phascolarctobacterium succinatutens YIT 12067,Phascolarctobacterium succinatutens,,periphery
+627192,Sphingobium sp. SYK-6,Sphingobium sp. SYK6,,periphery
+629265,Pseudomonas syringae pv. maculicola str. ES4326,Pseudomonas syringae maculicola,,periphery
+629742,Staphylococcus hominis SK119,Staphylococcus hominis SK119,,periphery
+629773,Sphingomonas sp. Mn802worker,Sphingomonas sp. Mn802worker,,periphery
+630626,Shimwellia blattae DSM4481,Shimwellia blattae,,core
+631362,Thiorhodovibrio sp. 970,Thiorhodovibrio sp. 970,,core
+631454,Lutibaculum baratangense AMV1,Lutibaculum baratangense,,periphery
+632245,Clostridium butyricum E4 str. BoNT E BL5262,Clostridium butyricum,,periphery
+632292,Caldicellulosiruptor hydrothermalis 108,Caldicellulosiruptor hydrothermalis,,periphery
+632335,Caldicellulosiruptor kristjanssonii I77R1B,Caldicellulosiruptor kristjanssonii,,periphery
+632518,Caldicellulosiruptor owensensis OL,Caldicellulosiruptor owensensis,,periphery
+633131,Thalassobium sp. R2A62,Thalassobium sp. R2A62,,core
+633147,Olsenella uli DSM7084,Olsenella uli,,core
+633148,Thermosphaera aggregans DSM11486,Thermosphaera aggregans,,core
+633149,Brevundimonas subvibrioides ATCC15264,Brevundimonas subvibrioides,,periphery
+633697,[Eubacterium] cellulosolvens 6,Eubacterium cellulosolvens 6,,core
+634176,Aggregatibacter aphrophilus NJ8700,Aggregatibacter aphrophilus,,periphery
+634177,Komagataeibacter medellinensis NBRC 3288,Komagataeibacter medellinensis,,periphery
+634452,Acetobacter pasteurianus IFO 3283-01,Acetobacter pasteurianus IFO328301,,core
+634497,Haloarcula hispanica ATCC33960,Haloarcula hispanica,,periphery
+634498,Methanobrevibacter ruminantium M1,Methanobrevibacter ruminantium,,core
+634499,Erwinia pyrifoliae Ep1/96,Erwinia pyrifoliae,,periphery
+634500,Erwinia billingiae Eb661,Erwinia billingiae,,core
+634504,Bartonella grahamii as4aup,Bartonella grahamii,,periphery
+634956,Geobacillus thermoglucosidasius C56-YS93,Geobacillus thermoglucosidasius,,periphery
+634994,Leptotrichia hofstadii F0254,Leptotrichia hofstadii,,core
+635013,Thermincola potens JR,Thermincola potens,,core
+637389,Acidithiobacillus caldus ATCC51756,Acidithiobacillus caldus,,core
+637390,Acidithiobacillus thiooxidans ATCC19377,Acidithiobacillus thiooxidans,,periphery
+637905,Shewanella violacea DSS12,Shewanella violacea,,periphery
+637910,Citrobacter rodentium ICC168,Citrobacter rodentium,,core
+637911,Actinobacillus minor NM305,Actinobacillus minor NM305,,periphery
+638301,Granulicatella adiacens ATCC49175,Granulicatella adiacens,,core
+638302,Selenomonas flueggei ATCC43531,Selenomonas flueggei,,core
+638303,Thermocrinis albus DSM14484,Thermocrinis albus,,periphery
+639030,Acidobacteria bacterium KBS 146,Acidobacteria bacterium KBS146,,core
+639282,Deferribacter desulfuricans SSM1,Deferribacter desulfuricans,,core
+639283,Starkeya novella DSM506,Starkeya novella,,periphery
+640081,Dechlorosoma suillum PS,Dechlorosoma suillum,,core
+640132,Segniliparus rotundus DSM44985,Segniliparus rotundus,,periphery
+640510,Burkholderia sp. CCGE1001,Burkholderia sp. CCGE1001,,core
+640511,Burkholderia sp. CCGE1002,Burkholderia sp. CCGE1002,,periphery
+640512,Burkholderia sp. CCGE1003,Burkholderia sp. CCGE1003,,core
+640513,Enterobacter asburiae LF7a,Enterobacter asburiae LF7a,,periphery
+641107,Clostridium sp. DL-VIII,Clostridium sp. DLVIII,,periphery
+641112,Ruminococcus flavefaciens FD-1,Ruminococcus flavefaciens FD1,,core
+641143,Capnocytophaga granulosa ATCC51502,Capnocytophaga granulosa,,periphery
+641146,Scardovia inopinata F0304,Scardovia inopinata,,core
+641147,Simonsiella muelleri ATCC29453,Simonsiella muelleri,,core
+641149,Neisseria sp. oral taxon 014 str. F0314,Neisseria sp. F0314,,periphery
+641491,Desulfovibrio desulfuricans ND132,Desulfovibrio desulfuricans ND132,,periphery
+641524,Cyclobacterium qasimii M12-11B,Cyclobacterium qasimii,,periphery
+641526,Winogradskyella psychrotolerans RS-3,Winogradskyella psychrotolerans,,core
+642227,Tatumella morbirosei,Tatumella morbirosei,,core
+642492,Clostridium lentocellum DSM5427,Clostridium lentocellum,,core
+643473,Microchaete sp. PCC7126,Microchaete sp. PCC7126,,periphery
+643562,Desulfovibrio aespoeensis Aspo-2,Desulfovibrio aespoeensis,,periphery
+643648,Syntrophothermus lipocalidus DSM12680,Syntrophothermus lipocalidus,,core
+643867,Marivirga tractuosa DSM4126,Marivirga tractuosa,,core
+644076,Silicibacter sp. TrichCH4B,Silicibacter sp. TrichCH4B,,core
+644107,Silicibacter lacuscaerulensis ITI-1157,Silicibacter lacuscaerulensis,,periphery
+644281,Methanocaldococcus sp. FS406-22,Methanocaldococcus sp. FS40622,,periphery
+644282,Desulfarculus baarsii DSM2075,Desulfarculus baarsii,,core
+644283,Micromonospora aurantiaca ATCC27029,Micromonospora aurantiaca,,periphery
+644284,Arcanobacterium haemolyticum DSM20595,Arcanobacterium haemolyticum,,core
+644548,Gordonia neofelifaecis NRRL B-59395,Gordonia neofelifaecis,,periphery
+644801,Pseudomonas stutzeri RCH2,Pseudomonas stutzeri RCH2,,periphery
+644966,Thermaerobacter marianensis DSM12885,Thermaerobacter marianensis,,core
+644968,Desulfovibrio sp. FW1012B,Desulfovibrio sp. FW1012B,,periphery
+645127,Corynebacterium kroppenstedtii DSM44385,Corynebacterium kroppenstedtii,,periphery
+645465,Streptomyces sp. e14,Streptomyces sp. e14,,periphery
+645512,Jonquetella anthropi E3_33 E1,Jonquetella anthropi E333E1,,periphery
+645991,Syntrophobotulus glycolicus DSM8271,Syntrophobotulus glycolicus,,core
+646529,Desulfosporosinus acidiphilus SJ4,Desulfosporosinus acidiphilus,,periphery
+647113,Methanothermococcus okinawensis IH1,Methanothermococcus okinawensis,,core
+648757,Rhodomicrobium vannielii ATCC17100,Rhodomicrobium vannielii,,core
+648885,Methylobacterium sp. MB200,Methylobacterium sp. MB200,,periphery
+648996,Thermovibrio ammonificans HB-1,Thermovibrio ammonificans,,core
+649349,Leadbetterella byssophila DSM17132,Leadbetterella byssophila,,core
+649638,Truepera radiovictrix DSM17093,Truepera radiovictrix,,core
+649639,Bacillus cellulosilyticus DSM2522,Bacillus cellulosilyticus,,periphery
+649743,Actinomyces sp. oral taxon 848 str. F0332,Actinomyces sp. F0332,,periphery
+649747,Aneurinibacillus aneurinilyticus ATCC12856,Aneurinibacillus aneurinilyticus,,core
+649754,Corynebacterium ammoniagenes DSM20306,Corynebacterium ammoniagenes,,periphery
+649761,Prevotella veroralis F0319,Prevotella veroralis F0319,,core
+649764,Slackia exigua ATCC700122,Slackia exigua,,periphery
+649831,Actinoplanes sp. N902-109,Actinoplanes sp. N902109,,periphery
+650150,Erysipelothrix rhusiopathiae str. Fujisawa,Erysipelothrix rhusiopathiae,,core
+652103,Rhodopseudomonas palustris DX-1,Rhodopseudomonas palustris DX1,,core
+653045,Streptomyces violaceusniger Tu 4113,Streptomyces violaceusniger,,periphery
+653386,Actinomyces sp. oral taxon 849 str. F0330,Actinomyces sp. F0330,,periphery
+653733,Desulfurispirillum indicum S5,Desulfurispirillum indicum,,core
+653948,Albugo laibachii,Albugo laibachii,,core
+655811,Anaerococcus vaginalis ATCC51170,Anaerococcus vaginalis,,periphery
+655812,Aerococcus viridans ATCC11563,Aerococcus viridans ATCC11563,,core
+655813,Streptococcus oralis ATCC35037,Streptococcus oralis ATCC35037,,core
+655815,Zunongwangia profunda SM-A87,Zunongwangia profunda,,core
+655981,Pseudogymnoascus destructans,Pseudogymnoascus destructans,,periphery
+656024,Frankia symbiont of Datisca glomerata,Frankia symbiont,,periphery
+656519,Halanaerobium hydrogeniformans,Halanaerobium hydrogeniformans,,core
+657309,Bacteroides xylanisolvens XB1A,Bacteroides xylanisolvens,,periphery
+657322,Faecalibacterium prausnitzii SL3/3,Faecalibacterium prausnitzii SL33,,periphery
+658086,Lachnospiraceae bacterium 3_1_57FAA_CT1,Lachnospiraceae bacterium 3157FAACT1,,periphery
+658088,Lachnospiraceae bacterium 9_1_43BFAA,Lachnospiraceae bacterium 9143BFAA,,periphery
+658172,Candidatus Liberibacter solanacearum CLso-ZC1,Liberibacter solanacearum,,core
+658187,Legionella drancourtii LLAP12,Legionella drancourtii,,periphery
+658612,Pseudomonas sp. H2,Pseudomonas sp. H2,,periphery
+658655,Lachnospiraceae bacterium 1_4_56FAA,Lachnospiraceae bacterium 1456FAA,,core
+658659,Erysipelotrichaceae bacterium 3_1_53,Erysipelotrichaceae bacterium 3153,,core
+660470,Mesotoga prima MesG1.Ag.4.2,Mesotoga prima,,core
+661087,Olsenella sp. oral taxon 809 str. F0356,Olsenella sp. F0356,,periphery
+661367,Legionella longbeachae NSW150,Legionella longbeachae,,core
+661478,Fimbriimonas ginsengisoli Gsoil 348,Fimbriimonas ginsengisoli,,periphery
+662479,Haloferax mucosum ATCC BAA-1512,Haloferax mucosum,,periphery
+662755,Corynebacterium resistens DSM45100,Corynebacterium resistens,,periphery
+663278,Ethanoligenens harbinense YUAN-3,Ethanoligenens harbinense,,core
+663321,Candidatus Regiella insecticola LSR1,Regiella insecticola,,core
+663610,Methylocapsa aurea,Methylocapsa aurea,,core
+663932,Acetobacter aceti ATCC23746,Acetobacter aceti ATCC23746,,periphery
+663952,Streptococcus dysgalactiae subsp. dysgalactiae ATCC27957,Streptococcus dysgalactiae ATCC27957,,periphery
+665029,Erwinia amylovora CFBP1430,Erwinia amylovora,,periphery
+665571,Spirochaeta thermophila DSM6192,Spirochaeta thermophila,,periphery
+665577,Streptomyces viridosporus T7A,Streptomyces viridosporus,,periphery
+665942,Desulfovibrio sp. 6_1_46AFAA,Desulfovibrio sp. 6146AFAA,,periphery
+665950,Lachnospiraceae bacterium 3_1_46FAA,Lachnospiraceae bacterium 3146FAA,,periphery
+665952,Bacillus smithii 7_3_47FAA,Bacillus smithii,,periphery
+665956,Subdoligranulum sp. 4_3_54A2FAA,Subdoligranulum sp. 4354A2FAA,,periphery
+665959,Bacillus sp. 2_A_57_CT2,Bacillus sp. 2A57CT2,,periphery
+666509,Planktomarina temperata RCA23,Planktomarina temperata,,core
+666510,Acidilobus saccharovorans 345-15,Acidilobus saccharovorans,,core
+666681,Methylotenera versatilis 301,Methylotenera versatilis,,core
+666684,Afipia sp. 1NLS2,Afipia sp. 1NLS2,,periphery
+666685,Rhodanobacter denitrificans,Rhodanobacter denitrificans,,periphery
+666686,Bacillus sp. 1NLA3E,Bacillus sp. 1NLA3E,,periphery
+667014,Thermodesulfatator indicus DSM15286,Thermodesulfatator indicus,,core
+667015,Bacteroides salanitronis DSM18170,Bacteroides salanitronis,,periphery
+667121,Edwardsiella tarda ATCC15947,Edwardsiella tarda ATCC15947,,core
+667632,Burkholderia sp. JPY347,Burkholderia sp. JPY347,,periphery
+669262,Mannheimia haemolytica serotype A2 str. BOVINE,Mannheimia haemolytica BOVINE,,periphery
+669502,Candidatus Profftella armatura,Profftella armatura,,core
+670292,Microvirga aerilata,Microvirga aerilata,,periphery
+670307,Hyphomicrobium denitrificans 1NES1,Hyphomicrobium denitrificans 1NES1,,periphery
+670487,Oceanithermus profundus DSM14977,Oceanithermus profundus,,core
+671065,Metallosphaera yellowstonensis MK1,Metallosphaera yellowstonensis,,periphery
+671143,Candidatus Methylomirabilis oxyfera,Methylomirabilis oxyfera,,core
+673860,Aciduliprofundum sp. MAR08-339,Aciduliprofundum sp. MAR08339,,periphery
+673862,Candidatus Babela massiliensis,Babela massiliensis,,periphery
+674977,Vibrio alginolyticus 40B,Vibrio alginolyticus 40B,,periphery
+675635,Pseudonocardia dioxanivorans CB1190,Pseudonocardia dioxanivorans,,core
+675806,Vibrio mimicus MB451,Vibrio mimicus,,periphery
+675812,Grimontia hollisae CIP 101886,Grimontia hollisae,,core
+675813,Vibrio metschnikovii CIP 69.14,Vibrio metschnikovii,,periphery
+675814,Vibrio coralliilyticus ATCC BAA-450,Vibrio coralliilyticus,,periphery
+675815,Vibrio sp. RC586,Vibrio sp. RC586,,periphery
+675816,Vibrio orientalis CIP 102891,Vibrio orientalis,,periphery
+675817,Photobacterium damselae subsp. damselae CIP 102761,Photobacterium damselae,,periphery
+676032,Francisella cf. tularensis subsp. novicida 3523,Francisella tularensis novicida,,periphery
+679189,Prevotella timonensis CRIS 5C-B1,Prevotella timonensis CRIS5CB1,,periphery
+679190,Prevotella buccalis ATCC35310,Prevotella buccalis ATCC35310,,periphery
+679191,Prevotella amnii CRIS 21A-A,Prevotella amnii,,core
+679192,Bulleidia extructa W1219,Bulleidia extructa,,core
+679197,Segniliparus rugosus ATCC BAA-974,Segniliparus rugosus,,core
+679199,Alloprevotella rava F0323,Alloprevotella rava,,periphery
+679200,Johnsonella ignava ATCC51276,Johnsonella ignava,,core
+679201,Selenomonas infelix ATCC43532,Selenomonas infelix,,periphery
+679897,Helicobacter mustelae 12198,Helicobacter mustelae,,periphery
+679926,Methanoplanus petrolearius DSM11571,Methanoplanus petrolearius,,core
+679935,Alistipes finegoldii DSM17242,Alistipes finegoldii,,periphery
+679937,Bacteroides coprosuis DSM18011,Bacteroides coprosuis,,periphery
+680198,Streptomyces scabiei 87.22,Streptomyces scabiei,,periphery
+680646,Rothia mucilaginosa DY-18,Rothia mucilaginosa,,core
+682795,Granulicella mallensis MP5ACTX8,Granulicella mallensis,,periphery
+683083,Campylobacter jejuni subsp. jejuni 414,Campylobacter jejuni 414,,periphery
+683837,Listeria seeligeri serovar 1/2b str. SLCC3954,Listeria seeligeri 12b,,periphery
+684719,alpha proteobacterium HIMB114,alpha proteobacterium HIMB114,,core
+684949,Deinococcus sp. 2009,Deinococcus sp. 2009,,periphery
+685035,Citromicrobium bathyomarinum JL354,Citromicrobium bathyomarinum,,core
+685727,Rhodococcus equi 103S,Rhodococcus equi,,core
+685778,Sphingomonas sp. PR090111-T3T-6A,Sphingomonas sp. PR090111T3T6A,,periphery
+685782,Bartonella rochalimae ATCC BAA-1498,Bartonella rochalimae,,periphery
+686340,Methylomicrobium album BG8,Methylomicrobium album,,periphery
+686578,Pseudomonas sp. S9,Pseudomonas sp. S9,,periphery
+688245,Comamonas testosteroni CNB-2,Comamonas testosteroni CNB2,,core
+688246,Prevotella multisaccharivorax DSM17128,Prevotella multisaccharivorax,,periphery
+688269,Thermotoga thermarum DSM5069,Thermotoga thermarum,,periphery
+688270,Cellulophaga algicola DSM14237,Cellulophaga algicola,,periphery
+689781,Oribacterium sp. NK2B42,Oribacterium sp. NK2B42,,core
+690585,Rhizobium vignae,Rhizobium vignae,,periphery
+690597,Pseudomonas fluorescens NZ007,Pseudomonas fluorescens NZ007,,periphery
+690850,Desulfovibrio africanus str. Walvis Bay,Desulfovibrio africanus,,periphery
+691883,Fonticula alba,Fonticula alba,,core
+693444,Enterobacteriaceae bacterium strain FGI 57,Enterobacteriaceae bacterium strain,,core
+693661,Archaeoglobus veneficus SNP6,Archaeoglobus veneficus,,core
+693746,Oscillibacter valericigenes Sjm18-20,Oscillibacter valericigenes,,core
+693977,Deinococcus proteolyticus MRP,Deinococcus proteolyticus,,core
+693979,Bacteroides helcogenes P 36-108,Bacteroides helcogenes,,periphery
+693986,Methylobacterium oryzae CBMB20,Methylobacterium oryzae,,periphery
+694427,Paludibacter propionicigenes WB4,Paludibacter propionicigenes,,core
+694429,Pyrolobus fumarii 1A,Pyrolobus fumarii,,core
+694430,Natronococcus occultus SP4,Natronococcus occultus,,periphery
+694431,Desulfurella acetivorans A63,Desulfurella acetivorans,,core
+694440,Methanomicrobium mobile BP,Methanomicrobium mobile,,periphery
+694569,Aggregatibacter actinomycetemcomitans D7S-1,Aggregatibacter actinomycetemcomitans D7S1,,periphery
+696125,Bartonella clarridgeiae 73,Bartonella clarridgeiae,,periphery
+696281,Desulfotomaculum ruminis DSM2154,Desulfotomaculum ruminis,,core
+696369,Desulfotomaculum nigrificans DSM574,Desulfotomaculum nigrificans,,core
+696747,Arthrospira platensis NIES-39,Arthrospira platensis NIES39,,core
+696748,Actinobacillus suis H91-0380,Actinobacillus suis,,periphery
+697281,Mahella australiensis 50-1 BON,Mahella australiensis,,core
+697282,Methylobacter tundripaludum SV96,Methylobacter tundripaludum,,core
+697284,Paenibacillus larvae subsp. larvae DSM25430,Paenibacillus larvae,,periphery
+697303,Thermoanaerobacter wiegelii Rt8.B1,Thermoanaerobacter wiegelii,,periphery
+697329,Ruminococcus albus 7,Ruminococcus albus 7,,periphery
+698440,Marssonina brunnea,Marssonina brunnea,,periphery
+698737,Staphylococcus lugdunensis HKU09-01,Staphylococcus lugdunensis HKU0901,,periphery
+698757,Pyrobaculum oguniense TE7,Pyrobaculum oguniense,,periphery
+698758,Amphibacillus xylanus NBRC 15112,Amphibacillus xylanus,,periphery
+698761,Rhizobium tropici CIAT 899,Rhizobium tropici,,periphery
+698769,Virgibacillus alimentarius,Virgibacillus alimentarius,,periphery
+698961,Gardnerella vaginalis 6119V5,Gardnerella vaginalis 6119V5,,periphery
+698964,Corynebacterium diphtheriae PW8,Corynebacterium diphtheriae,,periphery
+699218,Megasphaera genomosp. type_1 str. 28L,Megasphaera genomosp.,,periphery
+699246,Clostridiales genomosp. BVAB3 str. UPII9-5,Clostridiales genomosp.,,periphery
+699248,Streptococcus ratti FA-1,Streptococcus ratti,,periphery
+700015,Coriobacterium glomerans PW2,Coriobacterium glomerans,,core
+700508,Mycobacterium neoaurum VKM Ac-1815D,Mycobacterium neoaurum,,periphery
+700598,Niastella koreensis GR20-10,Niastella koreensis,,core
+701176,Vibrio sp. N418,Vibrio sp. N418,,periphery
+701347,Enterobacter lignolyticus SCF1,Enterobacter lignolyticus,,periphery
+701521,Pediococcus claussenii ATCC BAA-344,Pediococcus claussenii,,periphery
+702113,Novosphingobium sp. PP1Y,Novosphingobium sp. PP1Y,,periphery
+702437,Selenomonas noxia F0398,Selenomonas noxia F0398,,periphery
+702438,Prevotella oulorum F0390,Prevotella oulorum F0390,,periphery
+702450,Turicibacter sanguinis PC909,Turicibacter sanguinis,,core
+702459,Bifidobacterium bifidum PRL2010,Bifidobacterium bifidum PRL2010,,periphery
+706191,Pantoea ananatis LMG 20103,Pantoea ananatis LMG20103,,core
+706433,Solobacterium moorei F0204,Solobacterium moorei F0204,,core
+706434,Megasphaera micronuciformis F0359,Megasphaera micronuciformis,,periphery
+706436,Capnocytophaga sp. oral taxon 329 str. F0087,Capnocytophaga sp. F0087,,periphery
+706437,Streptococcus anginosus F0211,Streptococcus anginosus F0211,,periphery
+706439,Actinomyces sp. oral taxon 171 str. F0337,Actinomyces sp. F0337,,periphery
+706587,Desulfomonile tiedjei DSM6799,Desulfomonile tiedjei,,periphery
+708616,Mycoplasma gallisepticum str. F,Mycoplasma gallisepticum F,,periphery
+709032,Sulfuricurvum kujiense DSM16994,Sulfuricurvum kujiense,,periphery
+709797,Bradyrhizobiaceae bacterium SG-6C,Bradyrhizobiaceae bacterium SG6C,,core
+709986,Deinococcus maricopensis DSM21211,Deinococcus maricopensis,,periphery
+709991,Odoribacter splanchnicus DSM20712,Odoribacter splanchnicus,,core
+710111,Frankia sp. QA3,Frankia sp. QA3,,periphery
+710243,Colletotrichum fioriniae,Colletotrichum fioriniae,,periphery
+710393,Helicobacter suis HS1,Helicobacter suis,,periphery
+710421,Mycobacterium chubuense NBB4,Mycobacterium chubuense,,periphery
+710685,Mycobacterium rhodesiae NBB3,Mycobacterium rhodesiae NBB3,,periphery
+710686,Mycobacterium smegmatis JS623,Mycobacterium smegmatis JS623,,periphery
+710687,Mycobacterium tusciae JS617,Mycobacterium tusciae,,periphery
+710696,Intrasporangium calvum DSM43043,Intrasporangium calvum,,core
+711393,Streptomyces sp. GXT6,Streptomyces sp. GXT6,,periphery
+712898,Pantoea vagans C9-1,Pantoea vagans,,periphery
+713586,Thioalkalivibrio thiocyanodenitrificans ARhD 1,Thioalkalivibrio thiocyanodenitrificans,,periphery
+713587,Thioalkalivibrio thiocyanoxidans ARh4,Thioalkalivibrio thiocyanoxidans ARh4,,periphery
+713605,Lactobacillus iners AB-1,Lactobacillus iners,,periphery
+714083,Leucobacter chromiiresistens JG 31,Leucobacter chromiiresistens,,periphery
+714313,Lactobacillus sanfranciscensis TMW 1.1304,Lactobacillus sanfranciscensis,,periphery
+714943,Mucilaginibacter paludis DSM18603,Mucilaginibacter paludis,,core
+714961,Lysinibacillus fusiformis ZC1,Lysinibacillus fusiformis,,core
+715226,Asticcacaulis biprosthecum C19,Asticcacaulis biprosthecum,,periphery
+715451,Alteromonas sp. SN2,Alteromonas sp. SN2,,periphery
+716541,Enterobacter cloacae subsp. cloacae ATCC13047,Enterobacter cloacae ATCC13047,,core
+716544,Waddlia chondrophila WSU 86-1044,Waddlia chondrophila,,core
+716928,Ensifer sojae CCBAU 05684,Ensifer sojae,,periphery
+717231,Flexistipes sinusarabici DSM4947,Flexistipes sinusarabici,,periphery
+717605,Thermobacillus composti KWC4,Thermobacillus composti,,core
+717606,Paenibacillus curdlanolyticus YK9,Paenibacillus curdlanolyticus,,periphery
+717772,Thioalkalimicrobium aerophilum AL3,Thioalkalimicrobium aerophilum,,periphery
+717773,Thioalkalimicrobium cyclicum ALM1,Thioalkalimicrobium cyclicum,,core
+717774,Marinomonas mediterranea MMB-1,Marinomonas mediterranea,,periphery
+717785,Hyphomicrobium sp. MC1,Hyphomicrobium sp. MC1,,core
+718252,Faecalibacterium prausnitzii L2-6,Faecalibacterium prausnitzii L26,,core
+720554,[Clostridium] clariflavum DSM19732,Clostridium clariflavum,,core
+720555,Bacillus atrophaeus 1942,Bacillus atrophaeus,,periphery
+722419,Pseudoalteromonas haloplanktis ANT/505,Pseudoalteromonas haloplanktis ANT505,,core
+722438,Mycoplasma pneumoniae FH,Mycoplasma pneumoniae,,periphery
+740709,Idiomarina xiamenensis 10-D-4,Idiomarina xiamenensis,,periphery
+741091,Rahnella sp. Y9602,Rahnella sp. Y9602,,periphery
+742159,Achromobacter piechaudii ATCC43553,Achromobacter piechaudii ATCC43553,,periphery
+742722,Collinsella sp. 4_8_47FAA,Collinsella sp. 4847FAA,,periphery
+742723,Lachnospiraceae bacterium 2_1_46FAA,Lachnospiraceae bacterium 2146FAA,,periphery
+742725,Alistipes indistinctus YIT 12060,Alistipes indistinctus,,periphery
+742726,Barnesiella intestinihominis YIT 11860,Barnesiella intestinihominis,,core
+742727,Bacteroides oleiciplenus YIT 12058,Bacteroides oleiciplenus,,periphery
+742733,[Clostridium] citroniae WAL-17108,Clostridium citroniae,,periphery
+742735,[Clostridium] clostridioforme 2_1_49FAA,Clostridium clostridioforme,,periphery
+742738,Clostridium orbiscindens 1_3_50AFAA,Clostridium orbiscindens,,periphery
+742740,[Clostridium] symbiosum WAL-14163,Clostridium symbiosum WAL14163,,periphery
+742741,[Clostridium] symbiosum WAL-14673,Clostridium symbiosum WAL14673,,core
+742742,Collinsella tanakaei YIT 12063,Collinsella tanakaei,,periphery
+742743,Dialister succinatiphilus YIT 11850,Dialister succinatiphilus,,periphery
+742765,Dorea formicigenerans 4_6_53AFAA,Dorea formicigenerans 4653AFAA,,periphery
+742766,Dysgonomonas gadei ATCC BAA-286,Dysgonomonas gadei,,periphery
+742767,Dysgonomonas mossii DSM22836,Dysgonomonas mossii,,core
+742817,Odoribacter laneus YIT 12061,Odoribacter laneus,,periphery
+742818,Slackia piriformis YIT 12062,Slackia piriformis,,periphery
+742821,Sutterella wadsworthensis 3_1_45B,Sutterella wadsworthensis 3145B,,core
+742823,Sutterella wadsworthensis 2_1_59BFAA,Sutterella wadsworthensis 2159BFAA,,periphery
+743299,Acidithiobacillus ferrivorans SS3,Acidithiobacillus ferrivorans,,periphery
+743525,Thermus scotoductus SA-01,Thermus scotoductus,,core
+743718,Isoptericola variabilis 225,Isoptericola variabilis,,core
+743719,Paenibacillus lactis 154,Paenibacillus lactis,,periphery
+743720,Pseudomonas fulva 12-X,Pseudomonas fulva,,periphery
+743721,Pseudoxanthomonas suwonensis 11-1,Pseudoxanthomonas suwonensis 111,,core
+743722,Sphingobacterium sp. 21,Sphingobacterium sp. 21,,core
+743836,Methylocystis sp. SB2,Methylocystis sp. SB2,,core
+743965,Mycoplasma putrefaciens KS1,Mycoplasma putrefaciens KS1,,periphery
+743966,Mycoplasma bovoculi M165/69,Mycoplasma bovoculi,,periphery
+743974,Moraxella bovoculi 237,Moraxella bovoculi,,periphery
+744872,Treponema caldaria DSM7334,Treponema caldaria,,periphery
+744979,Ahrensia sp. R2A130,Ahrensia sp. R2A130,,core
+744980,Roseibium sp. TrichSKD4,Roseibium sp. TrichSKD4,,core
+744985,alpha proteobacterium HIMB59,alpha proteobacterium HIMB59,,periphery
+745014,gamma proteobacterium HIMB55,Gammaproteobacteria bacterium HIMB55,,periphery
+745277,Rahnella aquatilis CIP78.65,Rahnella aquatilis CIP78.65,,core
+745310,Sphingomonas sp. MM-1,Sphingomonas sp. MM1,,periphery
+745411,Gallaecimonas xiamenensis 3-C-1,Gallaecimonas xiamenensis,,core
+745718,Olleya sp. VCSM12,Olleya sp. VCSM12,,periphery
+745776,Deinococcus gobiensis I-0,Deinococcus gobiensis,,periphery
+746128,Aspergillus fumigatus,Aspergillus fumigatus,,core
+746697,Aequorivita sublithincola DSM14238,Aequorivita sublithincola,,core
+747365,Thermodesulfobium narugense DSM14796,Thermodesulfobium narugense,,core
+747682,Mycoplasma alligatoris A21JP2,Mycoplasma alligatoris,,periphery
+748224,Faecalibacterium cf. prausnitzii KLE1255,Faecalibacterium prausnitzii KLE1255,,periphery
+748247,Azoarcus sp. KH32C,Azoarcus sp. KH32C,,periphery
+748280,Pseudogulbenkiania sp. NH8B,Pseudogulbenkiania sp. NH8B,,periphery
+748449,Halobacteroides halobius DSM5150,Halobacteroides halobius,,periphery
+748658,Thioalkalivibrio sp. ALSr1,Thioalkalivibrio sp. ALSr1,,periphery
+748671,Lactobacillus crispatus ST1,Lactobacillus crispatus,,periphery
+748727,Clostridium ljungdahlii DSM13528,Clostridium ljungdahlii,,periphery
+749222,Nitratifractor salsuginis DSM16511,Nitratifractor salsuginis,,core
+749414,Streptomyces bingchenggensis BCW-1,Streptomyces bingchenggensis,,periphery
+749927,Amycolatopsis mediterranei U32,Amycolatopsis mediterranei,,core
+751944,Halobacterium sp. DL1,Halobacterium sp. DL1,,periphery
+751945,Thermus oshimai JL-2,Thermus oshimai,,periphery
+751994,gamma proteobacterium HIMB30,Gammaproteobacteria bacterium HIMB30,,periphery
+754027,Treponema phagedenis F0421,Treponema phagedenis,,periphery
+754035,Mesorhizobium australicum WSM2073,Mesorhizobium australicum,,periphery
+754252,Propionibacterium freudenreichii subsp. shermanii CIRM-BIA1,Propionibacterium freudenreichii,,periphery
+754331,Escherichia sp. TW09308,Escherichia sp. TW09308,,periphery
+754436,Photobacterium aphoticum,Photobacterium aphoticum,,periphery
+754476,Methylophaga nitratireducenticrescens,Methylophaga nitratireducenticrescens,,core
+754477,Methylophaga frappieri,Methylophaga frappieri,,core
+755178,Cyanobacterium aponinum PCC10605,Cyanobacterium aponinum,,core
+755731,Clostridium sp. BNL1100,Clostridium sp. BNL1100,,periphery
+755732,Fluviicola taffensis DSM16823,Fluviicola taffensis,,core
+756067,Microcoleus vaginatus FGP-2,Microcoleus vaginatus,,core
+756272,Planctomyces brasiliensis DSM5305,Planctomyces brasiliensis,,periphery
+756499,Desulfitobacterium dehalogenans ATCC51507,Desulfitobacterium dehalogenans,,core
+756883,Haloferacales archaeon DL31,Haloferacales archaeon DL31,,core
+757424,Herbaspirillum seropedicae SmR1,Herbaspirillum seropedicae,,core
+759362,Ketogulonicigenium vulgare WSH-001,Ketogulonicigenium vulgare,,core
+759913,Streptococcus dysgalactiae subsp. equisimilis AC-2713,Streptococcus dysgalactiae equisimilis,,core
+759914,Brachyspira pilosicoli 95/1000,Brachyspira pilosicoli,,periphery
+760011,Sphaerochaeta coccoides DSM17374,Sphaerochaeta coccoides,,periphery
+760117,Massilia consociata,Massilia consociata,,periphery
+760142,Hippea maritima DSM10411,Hippea maritima,,core
+760154,Sulfurospirillum barnesii SES-3,Sulfurospirillum barnesii,,periphery
+760192,Haliscomenobacter hydrossis DSM1100,Haliscomenobacter hydrossis,,core
+760568,Desulfotomaculum kuznetsovii DSM6115,Desulfotomaculum kuznetsovii,,core
+761193,Runella slithyformis DSM19594,Runella slithyformis,,core
+762051,Leuconostoc kimchii IMSNU 11154,Leuconostoc kimchii,,periphery
+762211,Bifidobacterium stellenboschense,Bifidobacterium stellenboschense,,core
+762376,Achromobacter xylosoxidans A8,Achromobacter xylosoxidans A8,,core
+762550,Leuconostoc gasicomitatum LMG 18811,Leuconostoc gasicomitatum,,periphery
+762903,Pedobacter saltans DSM12145,Pedobacter saltans,,periphery
+762948,Rothia dentocariosa ATCC17931,Rothia dentocariosa,,periphery
+762963,Actinomyces sp. oral taxon 170 str. F0386,Actinomyces sp. F0386,,periphery
+762966,Parasutterella excrementihominis YIT 11859,Parasutterella excrementihominis,,core
+762968,Paraprevotella clara YIT 11840,Paraprevotella clara,,periphery
+762982,Paraprevotella xylaniphila YIT 11841,Paraprevotella xylaniphila,,core
+762983,Succinatimonas hippei YIT 12066,Succinatimonas hippei,,core
+762984,Bacteroides clarus YIT 12056,Bacteroides clarus,,periphery
+763034,Bacteroides fluxus YIT 12057,Bacteroides fluxus,,periphery
+764291,Streptococcus urinalis 2285-97,Streptococcus urinalis 228597,,periphery
+764298,Streptococcus macacae NCTC 11558,Streptococcus macacae,,periphery
+764299,Streptococcus ictaluri 707-05,Streptococcus ictaluri,,periphery
+765123,Propionibacterium [acnes] HL037PA2,Propionibacterium acnes HL037PA2,,periphery
+765177,Desulfurococcus mucosus DSM2162,Desulfurococcus mucosus,,core
+765420,Oscillochloris trichoides DG-6,Oscillochloris trichoides,,periphery
+765698,Mesorhizobium ciceri biovar biserrulae WSM1271,Mesorhizobium ciceri biovar,,periphery
+765869,Bdellovibrio bacteriovorus W,Bdellovibrio bacteriovorus W,,periphery
+765910,Marichromatium purpuratum 984,Marichromatium purpuratum,,core
+765911,Thiocystis violascens DSM198,Thiocystis violascens,,core
+765912,Thioflavicoccus mobilis 8321,Thioflavicoccus mobilis,,core
+765913,Thiorhodococcus drewsii AZ1,Thiorhodococcus drewsii,,periphery
+765914,Thiorhodospira sibirica ATCC700588,Thiorhodospira sibirica,,periphery
+765952,Parachlamydia acanthamoebae UV-7,Parachlamydia acanthamoebae,,periphery
+766499,Citreicella sp. 357,Citreicella sp. 357,,periphery
+767029,Propionibacterium propionicum F0230a,Propionibacterium propionicum,,periphery
+767031,Prevotella denticola F0289,Prevotella denticola,,periphery
+767434,Frateuria aurantia DSM6220,Frateuria aurantia,,periphery
+767817,Desulfotomaculum gibsoniae DSM7213,Desulfotomaculum gibsoniae,,periphery
+768066,Halomonas elongata DSM2581,Halomonas elongata,,periphery
+768486,Enterococcus hirae ATCC9790,Enterococcus hirae,,periphery
+768670,Calditerrivibrio nitroreducens DSM19672,Calditerrivibrio nitroreducens,,periphery
+768671,Thiocapsa marina 5811,Thiocapsa marina,,core
+768672,Desulfurococcus fermentans DSM16532,Desulfurococcus fermentans,,periphery
+768679,Thermoproteus tenax Kra 1,Thermoproteus tenax,,core
+768704,Desulfosporosinus meridiei DSM13257,Desulfosporosinus meridiei,,core
+768706,Desulfosporosinus orientis DSM765,Desulfosporosinus orientis,,core
+768710,Desulfosporosinus youngiae DSM17734,Desulfosporosinus youngiae,,periphery
+768726,Streptococcus mitis bv. 2 str. F0392,Streptococcus mitis 2 F0392,,periphery
+771875,Fervidobacterium pennivorans DSM9078,Fervidobacterium pennivorans,,periphery
+794846,Sinorhizobium sp. CCBAU 05631,Sinorhizobium sp. CCBAU05631,,periphery
+794903,Opitutaceae bacterium TAV5,Opitutaceae bacterium TAV5,,periphery
+795359,Thermodesulfobacterium geofontis OPF15,Thermodesulfobacterium geofontis,,core
+795666,Ralstonia sp. PBA,Ralstonia sp. PBA,,periphery
+795797,Halalkalicoccus jeotgali B3,Halalkalicoccus jeotgali,,periphery
+795955,Nesterenkonia sp. F,Nesterenkonia sp. F,,periphery
+796606,Bacillus methanolicus MGA3,Bacillus methanolicus MGA3,,core
+796620,Vibrio caribbeanicus ATCC BAA-2122,Vibrio caribbeanicus,,periphery
+796940,Peptostreptococcaceae bacterium CM5,Peptostreptococcaceae bacterium CM5,,periphery
+796942,Stomatobaculum longum,Stomatobaculum longum,,core
+796945,Oribacterium parvum ACB8,Oribacterium parvum,,periphery
+797114,Halosimplex carlsbadense 2-9-1,Halosimplex carlsbadense,,periphery
+797209,Haladaptatus paucihalophilus DX253,Haladaptatus paucihalophilus,,core
+797210,Halopiger xanaduensis SH-6,Halopiger xanaduensis,,periphery
+797299,Halostagnicola larsenii XH-48,Halostagnicola larsenii,,periphery
+797302,Halovivax ruber XH-70,Halovivax ruber,,periphery
+797303,Natrinema pellirubrum DSM15624,Natrinema pellirubrum,,periphery
+797304,Natronobacterium gregoryi SP2,Natronobacterium gregoryi,,periphery
+797515,Lactobacillus parafarraginis F0439,Lactobacillus parafarraginis,,periphery
+838561,Spiroplasma mirum ATCC29335,Spiroplasma mirum,,periphery
+856793,Micavibrio aeruginosavorus ARL-13,Micavibrio aeruginosavorus ARL13,,core
+857087,Methylomonas methanica MC09,Methylomonas methanica,,periphery
+857290,Scardovia wiggsiae F0424,Scardovia wiggsiae,,periphery
+857293,Caloramator australicus RC3,Caloramator australicus,,periphery
+857571,Moraxella catarrhalis O35E,Moraxella catarrhalis,,core
+858215,Thermoanaerobacterium xylanolyticum LX-11,Thermoanaerobacterium xylanolyticum,,periphery
+858619,Corynebacterium variabile DSM44702,Corynebacterium variabile,,periphery
+859194,Mycoplasma haemofelis Ohio2,Mycoplasma haemofelis,,periphery
+859653,alpha proteobacterium HIMB5,alpha proteobacterium HIMB5,,core
+859657,Ralstonia solanacearum PSI07,Ralstonia solanacearum PSI07,,periphery
+860228,Capnocytophaga canimorsus Cc5,Capnocytophaga canimorsus,,periphery
+861208,Agrobacterium sp. H13-3,Agrobacterium sp. H133,,core
+861299,Gemmatimonadetes bacterium KBS708,Gemmatimonadetes bacterium KBS708,,core
+861360,Arthrobacter arilaitensis Re117,Arthrobacter arilaitensis,,periphery
+861450,Anaeroglobus geminatus F0357,Anaeroglobus geminatus,,core
+861452,Fusobacterium sp. oral taxon 370 str. F0437,Fusobacterium sp. F0437,,core
+861454,Lachnospiraceae bacterium oral taxon 082 str. F0431,Lachnospiraceae bacterium F0431,,periphery
+861455,Streptococcus sp. oral taxon 058 str. F0407,Streptococcus sp. F0407,,periphery
+861530,Staphylococcus sp. AL1,Staphylococcus sp. AL1,,periphery
+862514,Pediococcus acidilactici DSM20284,Pediococcus acidilactici DSM20284,,core
+862515,Prevotella marshii DSM16973,Prevotella marshii,,periphery
+862517,Peptoniphilus duerdenii ATCC BAA-1640,Peptoniphilus duerdenii,,periphery
+862751,Streptomyces sp. SirexAA-E,Streptomyces sp. SirexAAE,,periphery
+862908,Bacteriovorax marinus SJ,Bacteriovorax marinus,,core
+862965,Haemophilus parainfluenzae T3T1,Haemophilus parainfluenzae,,periphery
+862967,Streptococcus intermedius B196,Streptococcus intermedius,,periphery
+862969,Streptococcus constellatus subsp. pharyngis C1050,Streptococcus constellatus pharyngis C1050,,periphery
+862970,Streptococcus anginosus C1051,Streptococcus anginosus C1051,,periphery
+862971,Streptococcus anginosus C238,Streptococcus anginosus C238,,core
+863239,Corynebacterium nuruki S6-4,Corynebacterium nuruki,,periphery
+863365,Xanthomonas hortorum pv. carotae str. M081,Xanthomonas hortorum,,periphery
+864051,Burkholderiales bacterium JOSHI_001,Burkholderiales bacterium JOSHI001,,core
+864069,Microvirga lotononidis,Microvirga lotononidis,,core
+864073,Herbaspirillum frisingense GSF30,Herbaspirillum frisingense,,periphery
+864563,Selenomonas sp. oral taxon 149 str. 67H29BP,Selenomonas sp. 67H29BP,,periphery
+864564,Parascardovia denticolens DSM10105,Parascardovia denticolens DSM10105,,periphery
+864565,[Eubacterium] yurii subsp. margaretiae ATCC43715,Eubacterium yurii,,periphery
+864567,Streptococcus mitis ATCC6249,Streptococcus mitis ATCC6249,,periphery
+864570,Streptococcus sp. oral taxon 071 str. 73H25AP,Streptococcus sp. 73H25AP,,periphery
+864702,Oscillatoriales cyanobacterium JSC-12,Oscillatoriales cyanobacterium,,core
+865861,Clostridium ultunense DSM10521,Clostridium ultunense,,periphery
+865937,Gillisia limnaea DSM15749,Gillisia limnaea,,periphery
+865938,Weeksella virosa DSM16922,Weeksella virosa,,core
+866536,Belliella baltica DSM15883,Belliella baltica,,periphery
+866546,Schizosaccharomyces cryophilus,Schizosaccharomyces cryophilus,,periphery
+866771,Prevotella disiens FB035-09AN,Prevotella disiens FB03509AN,,periphery
+866774,Atopobium vaginae PB189-T1-4,Atopobium vaginae PB189T14,,periphery
+866775,Aerococcus urinae ACS-120-V-Col10a,Aerococcus urinae,,periphery
+866776,Veillonella atypica ACS-049-V-Sch6,Veillonella atypica ACS049VSch6,,core
+866895,Halobacillus halophilus DSM2266,Halobacillus halophilus,,periphery
+867845,Chloroflexus sp. Y-396-1,Chloroflexus sp. Y3961,,periphery
+867900,Cellulophaga lytica DSM7489,Cellulophaga lytica,,core
+867902,Ornithobacterium rhinotracheale DSM15997,Ornithobacterium rhinotracheale,,core
+867903,Thermaerobacter subterraneus DSM13965,Thermaerobacter subterraneus,,periphery
+868131,Methanobacterium paludis,Methanobacterium paludis,,core
+868595,Desulfotomaculum carboxydivorans CO-1-SRB,Desulfotomaculum carboxydivorans,,periphery
+868864,Desulfurobacterium thermolithotrophum DSM11699,Desulfurobacterium thermolithotrophum,,core
+869209,Treponema succinifaciens DSM2489,Treponema succinifaciens,,periphery
+869210,Marinithermus hydrothermalis DSM14884,Marinithermus hydrothermalis,,core
+869213,Cytophaga fermentans DSM9555,Cytophaga fermentans,,periphery
+870187,Thiothrix nivea DSM5205,Thiothrix nivea,,core
+870967,Vibrio scophthalmi LMG 19158,Vibrio scophthalmi,,periphery
+871585,Acinetobacter calcoaceticus PHEA-2,Acinetobacter calcoaceticus,,periphery
+871963,Desulfitobacterium dichloroeliminans LMG P-21439,Desulfitobacterium dichloroeliminans,,periphery
+871968,Desulfitobacterium metallireducens DSM15288,Desulfitobacterium metallireducens,,periphery
+873447,Streptococcus parauberis NCFD 2020,Streptococcus parauberis NCFD2020,,periphery
+873448,Streptococcus porcinus str. Jelinkova 176,Streptococcus porcinus,,periphery
+873449,Streptococcus criceti HS-6,Streptococcus criceti,,periphery
+873513,Prevotella buccae ATCC33574,Prevotella buccae ATCC33574,,periphery
+873517,Capnocytophaga ochracea F0287,Capnocytophaga ochracea F0287,,periphery
+873533,Prevotella oralis ATCC33269,Prevotella oralis ATCC33269,,periphery
+875328,Mycobacterium sp. JDM601,Mycobacterium sp. JDM601,,core
+875454,Peptoniphilus rhinitidis 1-13,Peptoniphilus rhinitidis,,periphery
+876044,gamma proteobacterium IMCC3088,Gammaproteobacteria bacterium IMCC3088,,periphery
+876269,Methyloferula stellata AR4,Methyloferula stellata,,core
+877411,Ruminococcus sp. NK3A76,Ruminococcus sp. NK3A76,,periphery
+877414,Clostridiales bacterium NK3B98,Clostridiales bacterium NK3B98,,core
+877415,Erysipelotrichaceae bacterium NK3D112,Erysipelotrichaceae bacterium NK3D112,,periphery
+877418,Treponema bryantii NK4A124,Treponema bryantii,,periphery
+877420,Lachnospiraceae bacterium NK4A136,Lachnospiraceae bacterium NK4A136,,periphery
+877421,Lachnospiraceae bacterium NK4A144,Lachnospiraceae bacterium NK4A144,,core
+877424,Lachnospiraceae bacterium NK4A179,Lachnospiraceae bacterium NK4A179,,periphery
+877455,Methanobacterium lacus,Methanobacterium lacus,,core
+879212,Desulfobacter postgatei 2ac9,Desulfobacter postgatei,,periphery
+879243,Porphyromonas asaccharolytica DSM20707,Porphyromonas asaccharolytica,,periphery
+879305,Anaerococcus prevotii ACS-065-V-Col13,Anaerococcus prevotii ACS065VCol13,,periphery
+879308,Peptoniphilus sp. oral taxon 375 str. F0436,Peptoniphilus sp. F0436,,periphery
+879309,Veillonella sp. oral taxon 158 str. F0412,Veillonella sp. F0412,,core
+879310,Selenomonas sp. oral taxon 137 str. F0430,Selenomonas sp. F0430,,periphery
+880070,Cyclobacterium marinum DSM745,Cyclobacterium marinum,,core
+880071,Flexibacter litoralis DSM6794,Flexibacter litoralis,,core
+880072,Desulfobacca acetoxidans DSM11109,Desulfobacca acetoxidans,,core
+880073,Caldithrix abyssi DSM13497,Caldithrix abyssi,,core
+880074,Barnesiella viscericola DSM18177,Barnesiella viscericola,,periphery
+880447,Mycoplasma leachii PG50,Mycoplasma leachii,,core
+880526,Rikenella microfusus DSM15922,Rikenella microfusus,,core
+881621,Listeria ivanovii subsp. ivanovii PAM 55,Listeria ivanovii PAM55,,periphery
+882082,Saccharomonospora cyanea NA-134,Saccharomonospora cyanea,,periphery
+882083,Saccharomonospora marina XMU15,Saccharomonospora marina,,periphery
+882086,Saccharomonospora xinjiangensis XJ-54,Saccharomonospora xinjiangensis,,periphery
+882378,Burkholderia rhizoxinica HKI 454,Burkholderia rhizoxinica,,periphery
+883066,Actinobaculum massiliae ACS-171-V-Col2,Actinobaculum massiliae,,periphery
+883067,Actinobaculum schaalii FB123-CNA-2,Actinobaculum schaalii,,periphery
+883069,Actinomyces europaeus ACS-120-V-Col10b,Actinomyces europaeus,,periphery
+883077,Actinomyces turicensis ACS-279-V-Col4,Actinomyces turicensis,,periphery
+883078,Afipia broomeae ATCC49717,Afipia broomeae,,periphery
+883080,Afipia felis ATCC53690,Afipia felis,,periphery
+883081,Alloiococcus otitis ATCC51267,Alloiococcus otitis,,core
+883096,Bergeyella zoohelcum ATCC43767,Bergeyella zoohelcum,,core
+883103,Dolosigranulum pigrum ATCC51524,Dolosigranulum pigrum,,core
+883109,Eubacterium infirmum F0142,Eubacterium infirmum,,core
+883110,Facklamia hominis ACS-120-V-Sch10,Facklamia hominis,,core
+883112,Facklamia ignava CCUG 37419,Facklamia ignava,,periphery
+883113,Facklamia languida CCUG 37842,Facklamia languida,,core
+883114,Helcococcus kunzii ATCC51366,Helcococcus kunzii,,core
+883126,Massilia timonae CCUG 45783,Massilia timonae,,periphery
+883156,Veillonella ratti ACS-216-V-Col6b,Veillonella ratti,,periphery
+883158,Prevotella micans F0438,Prevotella micans,,periphery
+883168,Streptococcus urinalis FB127-CNA-2,Streptococcus urinalis FB127CNA2,,periphery
+883169,Turicella otitidis ATCC51513,Turicella otitidis,,core
+885272,Jonquetella anthropi DSM22815,Jonquetella anthropi DSM22815,,core
+885580,Fukomys damarensis,Fukomys damarensis,,periphery
+886293,Singulisphaera acidiphila DSM18658,Singulisphaera acidiphila,,core
+886377,Muricauda ruestringensis DSM13258,Muricauda ruestringensis,,core
+886379,Anaerophaga thermohalophila DSM12881,Anaerophaga thermohalophila,,core
+886882,Paenibacillus polymyxa SC2,Paenibacillus polymyxa SC2,,periphery
+887062,Hylemonella gracilis ATCC19624,Hylemonella gracilis ATCC19624,,core
+887325,Lachnoanaerobaculum saburreum DSM3986,Lachnoanaerobaculum saburreum DSM3986,,core
+887327,Kingella kingae ATCC23330,Kingella kingae,,core
+887898,Lautropia mirabilis ATCC51599,Lautropia mirabilis,,core
+887929,Pseudoramibacter alactolyticus ATCC23263,Pseudoramibacter alactolyticus,,core
+888048,Streptococcus parasanguinis ATCC903,Streptococcus parasanguinis ATCC903,,periphery
+888049,Streptococcus oralis ATCC49296,Streptococcus oralis ATCC49296,,periphery
+888050,Actinomyces cardiffensis F0333,Actinomyces cardiffensis,,periphery
+888052,Actinomyces sp. oral taxon 180 str. F0310,Actinomyces sp. F0310,,periphery
+888055,Leptotrichia wadei F0279,Leptotrichia wadei,,periphery
+888056,Actinomyces sp. oral taxon 448 str. F0400,Actinomyces sp. F0400,,core
+888059,Capnocytophaga sp. oral taxon 338 str. F0234,Capnocytophaga sp. F0234,,periphery
+888060,Centipeda periodontii DSM2778,Centipeda periodontii,,core
+888062,Dialister micraerophilus DSM19965,Dialister micraerophilus,,periphery
+888064,Enterococcus italicus DSM15952,Enterococcus italicus,,periphery
+888439,Actinomyces neuii BVS029A5,Actinomyces neuii BVS029A5,,periphery
+888727,Eubacterium sulci ATCC35585,Eubacterium sulci,,core
+888743,Prevotella multiformis DSM16608,Prevotella multiformis,,periphery
+888746,Streptococcus peroris ATCC700780,Streptococcus peroris,,core
+888808,Streptococcus sanguinis SK49,Streptococcus sanguinis SK49,,periphery
+888816,Streptococcus sanguinis SK355,Streptococcus sanguinis SK355,,periphery
+888821,Streptococcus sanguinis SK1057,Streptococcus sanguinis SK1057,,periphery
+888832,Prevotella salivae DSM15606,Prevotella salivae,,periphery
+888833,Streptococcus australis ATCC700641,Streptococcus australis,,periphery
+889201,Streptococcus cristatus ATCC51100,Streptococcus cristatus,,periphery
+889204,Streptococcus infantis ATCC700779,Streptococcus infantis ATCC700779,,periphery
+889378,Spirochaeta africana DSM8902,Spirochaeta africana,,periphery
+891391,Lactobacillus acidophilus 30SC,Lactobacillus acidophilus 30SC,,core
+891968,Anaerobaculum mobile DSM13181,Anaerobaculum mobile,,core
+891974,Plautia stali symbiont,Plautia stali,,periphery
+903503,Candidatus Moranella endobia PCIT,Moranella endobia,,core
+903814,Eubacterium limosum KIST612,Eubacterium limosum,,core
+903818,Holophaga foetida DSM6591,Holophaga foetida,,periphery
+904144,Gardnerella vaginalis 101,Gardnerella vaginalis 101,,periphery
+904293,Streptococcus downei F0415,Streptococcus downei,,periphery
+904294,Streptococcus sp. oral taxon 056 str. F0418,Streptococcus sp. F0418,,periphery
+904296,Oribacterium sp. oral taxon 108 str. F0425,Oribacterium sp. F0425,,periphery
+904306,Streptococcus vestibularis F0396,Streptococcus vestibularis,,periphery
+904314,Staphylococcus pettenkoferi VCU012,Staphylococcus pettenkoferi,,periphery
+906888,Nonlabens ulvanivorans,Nonlabens ulvanivorans,,core
+906968,Treponema brennaborense DSM12168,Treponema brennaborense,,periphery
+907239,Helicobacter pylori SouthAfrica7,Helicobacter pylori SouthAfrica7,,periphery
+907348,Treponema saccharophilum DSM2985,Treponema saccharophilum,,periphery
+907931,Leuconostoc fallax KCTC 3537,Leuconostoc fallax,,core
+908337,Eremococcus coleocola ACS-139-V-Col8,Eremococcus coleocola ACS139VCol8,,core
+908338,Peptoniphilus harei ACS-146-V-Sch2b,Peptoniphilus harei,,core
+908339,Lactobacillus oris PB013-T2-3,Lactobacillus oris PB013T23,,periphery
+908340,Clostridium sp. HGF2,Clostridium sp. HGF2,,periphery
+908612,Alistipes sp. HGB5,Alistipes sp. HGB5,,core
+908937,Prevotella dentalis DSM3688,Prevotella dentalis,,periphery
+909613,Actinokineospora sp. EG49,Actinokineospora sp. EG49,,periphery
+909663,Syntrophorhabdus aromaticivorans UI,Syntrophorhabdus aromaticivorans,,core
+909943,SAR116 cluster alpha proteobacterium HIMB100,Alphaproteobacterium SAR116,,periphery
+910313,Streptococcus pseudoporcinus SPIN 20026,Streptococcus pseudoporcinus,,periphery
+910314,Dialister microaerophilus UPII 345-E,Dialister microaerophilus,,core
+910964,Ewingella americana ATCC33852,Ewingella americana,,core
+911008,Leclercia adecarboxylata ATCC23216,Leclercia adecarboxylata,,core
+911045,Pseudovibrio sp. FO-BEG1,Pseudovibrio sp. FOBEG1,,core
+911104,Weissella cibaria KACC 11862,Weissella cibaria,,core
+911239,Pseudomonas sp. CF149,Pseudomonas sp. CF149,,periphery
+913325,Lysobacter arseniciresistens ZS79,Lysobacter arseniciresistens,,periphery
+913848,Lactobacillus coryniformis KCTC3167,Lactobacillus coryniformis KCTC3167,,periphery
+913865,Desulfosporosinus sp. OT,Desulfosporosinus sp. OT,,periphery
+925409,Sediminibacterium sp. OR53,Sediminibacterium sp. OR53,,periphery
+925775,Xanthomonas vesicatoria ATCC35937,Xanthomonas vesicatoria,,periphery
+926549,Adhaeribacter aquaticus DSM16391,Adhaeribacter aquaticus,,core
+926550,Caldilinea aerophila DSM14535,Caldilinea aerophila,,core
+926551,Capnocytophaga cynodegmi DSM19736,Capnocytophaga cynodegmi,,periphery
+926554,Deinococcus pimensis DSM21231,Deinococcus pimensis,,periphery
+926556,Echinicola vietnamensis DSM17526,Echinicola vietnamensis,,periphery
+926559,Joostella marina DSM19592,Joostella marina,,core
+926560,Meiothermus chliarophilus DSM9957,Meiothermus chliarophilus,,core
+926561,Orenia marismortui DSM5156,Orenia marismortui,,core
+926562,Owenweeksia hongkongensis DSM17368,Owenweeksia hongkongensis,,periphery
+926564,Promicromonospora kroppenstedtii DSM19349,Promicromonospora kroppenstedtii,,periphery
+926566,Terriglobus roseus DSM18391,Terriglobus roseus,,periphery
+926567,Thermanaerovibrio velox DSM12556,Thermanaerovibrio velox,,periphery
+926569,Anaerolinea thermophila UNI-1,Anaerolinea thermophila,,core
+926690,Haloplanus natans DSM17983,Haloplanus natans,,periphery
+926692,Halonatronum saccharophilum DSM13868,Halonatronum saccharophilum,,periphery
+927658,Alkaliflexus imshenetskii DSM15055,Alkaliflexus imshenetskii,,periphery
+927666,Streptococcus oralis Uo5,Streptococcus oralis Uo5,,periphery
+927677,Synechocystis sp. PCC7509,Synechocystis sp. PCC7509,,periphery
+927691,Leuconostoc gelidum KCTC 3527,Leuconostoc gelidum KCTC3527,,periphery
+927704,Selenomonas ruminantium subsp. lactilytica TAM6421,Selenomonas ruminantium lactilytica,,periphery
+928210,Bartonella sp. R4(2010),Bartonella sp. R4,,periphery
+928724,Saccharomonospora glauca K62,Saccharomonospora glauca,,periphery
+929506,Clostridium botulinum BKT015925,Clostridium botulinum BKT015925,,periphery
+929556,Solitalea canadensis DSM3403,Solitalea canadensis,,core
+929558,Sulfurimonas gotlandica GD1,Sulfurimonas gotlandica,,periphery
+929562,Emticicia oligotrophica DSM17448,Emticicia oligotrophica,,core
+929703,Flectobacillus major DSM103,Flectobacillus major,,core
+929704,Myroides odoratus DSM2801,Myroides odoratus,,core
+929712,Patulibacter minatonensis DSM18081,Patulibacter minatonensis,,periphery
+929713,Niabella soli DSM19437,Niabella soli,,periphery
+929794,Bartonella senegalensis OS02,Bartonella senegalensis,,periphery
+930166,Pseudomonas brassicacearum,Pseudomonas brassicacearum,,periphery
+930169,Alcanivorax dieselolei B5,Alcanivorax dieselolei,,periphery
+930171,Arthrobacter phenanthrenivorans Sphe3,Arthrobacter phenanthrenivorans,,periphery
+930945,Sulfolobus islandicus REY15A,Sulfolobus islandicus,,periphery
+930946,Fructobacillus fructosus KCTC 3544,Fructobacillus fructosus,,core
+931276,Clostridium saccharoperbutylacetonicum N1-4(HMT),Clostridium saccharoperbutylacetonicum,,periphery
+931277,Halococcus morrhuae DSM1307,Halococcus morrhuae,,periphery
+931626,Acetobacterium woodii DSM1030,Acetobacterium woodii,,core
+931627,Mycobacterium rhodesiae JS60,Mycobacterium rhodesiae JS60,,periphery
+932213,Serratia sp. M24T3,Serratia sp. M24T3,,periphery
+932677,Pantoea ananatis AJ13355,Pantoea ananatis AJ13355,,periphery
+932678,Thermocrinis ruber DSM12173,Thermocrinis ruber,,periphery
+933115,Planococcus donghaensis MPA1U2,Planococcus donghaensis,,core
+933262,Desulfosarcina sp. BuS5,Desulfosarcina sp. BuS5,,core
+933801,Acidianus hospitalis W1,Acidianus hospitalis,,core
+935261,Aminobacter sp. J41,Aminobacter sp. J41,,periphery
+935548,Mesorhizobium loti R88b,Mesorhizobium loti R88b,,periphery
+935557,Sinorhizobium arboris LMG 14919,Sinorhizobium arboris,,periphery
+935565,Paracoccus pantotrophus J46,Paracoccus pantotrophus,,periphery
+935567,Pseudoxanthomonas suwonensis J43,Pseudoxanthomonas suwonensis J43,,periphery
+935836,Bacillus sp. J33,Bacillus sp. J33,,periphery
+935837,Bacillus sp. J37,Bacillus sp. J37,,periphery
+935839,Cellulosimicrobium cellulans J36,Cellulosimicrobium cellulans,,periphery
+935840,Chelativorans sp. J32,Chelativorans sp. J32,,periphery
+935845,Paenibacillus sp. J14,Paenibacillus sp. J14,,periphery
+935848,Paracoccus sp. J39,Paracoccus sp. J39,,core
+935863,Luteimonas sp. J29,Luteimonas sp. J29,,periphery
+935866,Nocardioides sp. J54,Nocardioides sp. J54,,periphery
+935948,Caldanaerobius polysaccharolyticus DSM13641,Caldanaerobius polysaccharolyticus,,core
+936053,Rhizopus delemar,Rhizopus delemar,,core
+936136,Rhizobium leguminosarum bv. viciae 248,Rhizobium leguminosarum 248,,periphery
+936140,Lactobacillus farciminis KCTC 3681,Lactobacillus farciminis,,periphery
+936154,Streptococcus parauberis KCTC 11537,Streptococcus parauberis KCTC11537,,periphery
+936155,Helicobacter felis ATCC49179,Helicobacter felis,,periphery
+936375,Mogibacterium sp. CM50,Mogibacterium sp. CM50,,periphery
+936455,Bradyrhizobium genosp. SA-4 str. CB756,Bradyrhizobium genosp.,,periphery
+936548,Actinomyces sp. ICM47,Actinomyces sp. ICM47,,periphery
+936550,Atopobium sp. BS2,Atopobium sp. BS2,,periphery
+936572,Selenomonas sp. FOBRC6,Selenomonas sp. FOBRC6,,core
+936573,Selenomonas sp. FOBRC9,Selenomonas sp. FOBRC9,,periphery
+936574,Shuttleworthia sp. MSX8B,Shuttleworthia sp. MSX8B,,periphery
+936580,Streptococcus sp. CM6,Streptococcus sp. CM6,,periphery
+936589,Veillonella sp. AS16,Veillonella sp. AS16,,periphery
+936596,Lachnoanaerobaculum sp. MSX33,Lachnoanaerobaculum sp. MSX33,,periphery
+937774,Taylorella equigenitalis MCE9,Taylorella equigenitalis,,periphery
+937777,Deinococcus peraridilitoris DSM19664,Deinococcus peraridilitoris,,periphery
+938278,Clostridiales bacterium 9400853,Clostridiales bacterium 9400853,,periphery
+938288,Clostridiales bacterium 9401234,Clostridiales bacterium 9401234,,periphery
+938289,Clostridiales bacterium 9403326,Clostridiales bacterium 9403326,,periphery
+938293,Anaerococcus sp. 9402080,Anaerococcus sp. 9402080,,core
+938709,Bacteroidetes bacterium SCGC AAA027-N21,Bacteroidetes bacterium SCGC AAA027N21,,core
+940282,Acetobacter pasteurianus 3P3,Acetobacter pasteurianus 3P3,,periphery
+941449,Desulfovibrio sp. X2,Desulfovibrio sp. X2,,periphery
+941639,Bacillus coagulans 2-6,Bacillus coagulans 26,,periphery
+941770,Lactobacillus fructivorans KCTC3543,Lactobacillus fructivorans,,core
+941824,Thermobrachium celere DSM8682,Thermobrachium celere,,core
+944435,Burkholderia sp. WSM2230,Burkholderia sp. WSM2230,,periphery
+944479,Hippea jasoniae,Hippea jasoniae,,periphery
+944480,Hippea alviniae EP5-r,Hippea alviniae,,periphery
+944481,Hippea sp. KM1,Hippea sp. KM1,,periphery
+944546,Arcobacter butzleri ED-1,Arcobacter butzleri ED1,,periphery
+944547,Arcobacter sp. L,Arcobacter sp. L,,periphery
+944560,Actinomyces sp. oral taxon 175 str. F0384,Actinomyces sp. F0384,,periphery
+944562,Lactobacillus oris F0423,Lactobacillus oris F0423,,periphery
+944564,Veillonella sp. oral taxon 780 str. F0422,Veillonella sp. F0422,,periphery
+944565,Parvimonas sp. oral taxon 393 str. F0440,Parvimonas sp. F0440,,periphery
+945021,Tetragenococcus halophilus NBRC 12172,Tetragenococcus halophilus,,core
+945543,Vibrio brasiliensis LMG 20546,Vibrio brasiliensis,,periphery
+945550,Vibrio sinaloensis DSM21326,Vibrio sinaloensis,,periphery
+945712,Corynebacterium ulcerans BR-AD22,Corynebacterium ulcerans,,periphery
+945713,Ignavibacterium album JCM 16511,Ignavibacterium album,,core
+946077,Imtechella halotolerans K1,Imtechella halotolerans,,core
+946235,Oceanobacillus massiliensis str. N'diop,Oceanobacillus massiliensis,,periphery
+946362,Salpingoeca rosetta,Salpingoeca rosetta,,periphery
+946483,Candidatus Symbiobacter mobilis CR,Symbiobacter mobilis,,core
+948106,Burkholderia dilworthii,Burkholderia dilworthii,,periphery
+948565,Avibacterium paragallinarum 72,Avibacterium paragallinarum 72,,periphery
+953739,Streptomyces venezuelae ATCC10712,Streptomyces venezuelae,,periphery
+977880,Cupriavidus taiwanensis LMG 19424,Cupriavidus taiwanensis,,core
+979556,Microbacterium testaceum StLB037,Microbacterium testaceum,,core
+980584,Flavobacteriaceae bacterium HQM9,Flavobacteriaceae bacterium HQM9,,core
+981085,Morus notabilis,Morus notabilis,,periphery
+981223,Acinetobacter sp. NCTC 7422,Acinetobacter sp. NCTC 7422,,periphery
+981327,Acinetobacter lwoffii NCTC5866,Acinetobacter lwoffii NCTC 5866,,periphery
+981336,Acinetobacter ursingii DSM16037,Acinetobacter ursingii,,periphery
+981369,Streptacidiphilus rugosus AM-16,Streptacidiphilus rugosus,,periphery
+981383,Ornithinibacillus scapharcae TW25,Ornithinibacillus scapharcae,,core
+981384,Ruegeria conchae,Ruegeria conchae,,periphery
+983328,Campylobacter fetus subsp. venerealis NCTC10354,Campylobacter fetus venerealis,,periphery
+983544,Lacinutrix sp. 5H-3-7-4,Lacinutrix sp. 5H374,,core
+983545,Glaciecola sp. 4H-3-7+YE-5,Glaciecola sp. 4H37YE5,,core
+983548,Dokdonia sp. 4H-3-7-5,Dokdonia sp. 4H375,,periphery
+983917,Rubrivivax gelatinosus IL144,Rubrivivax gelatinosus,,periphery
+983920,Novosphingobium nitrogenifigens DSM19370,Novosphingobium nitrogenifigens,,periphery
+984262,Saprospira grandis str. Lewin,Saprospira grandis,,periphery
+984892,Staphylococcus pseudintermedius ED99,Staphylococcus pseudintermedius,,periphery
+984962,Heterobasidion irregulare,Heterobasidion irregulare,,periphery
+985053,Vulcanisaeta moutnovskia 768-28,Vulcanisaeta moutnovskia,,periphery
+985054,Ruegeria halocynthiae,Ruegeria halocynthiae,,periphery
+985255,Gillisia sp. CAL575,Gillisia sp. CAL575,,periphery
+985665,Paenibacillus terrae HPL-003,Paenibacillus terrae,,periphery
+985762,Staphylococcus agnetis,Staphylococcus agnetis,,periphery
+985867,Candidatus Odyssella thessalonicensis L13,Odyssella thessalonicensis,,core
+986075,Caldalkalibacillus thermarum TA2.A1,Caldalkalibacillus thermarum,,core
+987059,Rubrivivax benzoatilyticus JA2,Rubrivivax benzoatilyticus,,core
+990073,Lebetimonas sp. JS170,Lebetimonas sp. JS170,,periphery
+990285,Rhizobium grahamii CCGE 502,Rhizobium grahamii,,periphery
+991905,Polymorphum gilvum SL003B-26A1,Polymorphum gilvum,,core
+992406,Riemerella anatipestifer RA-GD,Riemerella anatipestifer,,core
+994479,Saccharopolyspora spinosa NRRL 18395,Saccharopolyspora spinosa,,periphery
+994573,Youngiibacter fragilis 232.1,Youngiibacter fragilis,,core
+996306,Streptococcus suis R61,Streptococcus suis R61,,periphery
+996637,Streptomyces griseoaurantiacus M045,Streptomyces griseoaurantiacus,,core
+997296,Bacillus methanolicus PB1,Bacillus methanolicus PB1,,periphery
+997346,Desmospora sp. 8437,Desmospora sp. 8437,,core
+997350,Peptoniphilus indolicus ATCC29427,Peptoniphilus indolicus,,core
+997352,Prevotella nigrescens ATCC33563,Prevotella nigrescens,,periphery
+997353,Prevotella pallens ATCC700821,Prevotella pallens,,periphery
+997829,Porphyromonas sp. KLE 1280,Porphyromonas sp. KLE1280,,periphery
+997830,Streptococcus infantis X,Streptococcus infantis X,,periphery
+997884,Bacteroides nordii CL02T12C05,Bacteroides nordii,,periphery
+998088,Aeromonas veronii B565,Aeromonas veronii,,core
+998674,Leucothrix mucor DSM2157,Leucothrix mucor,,core
+999141,Halomonas sp. TD01,Halomonas sp. TD01,,core
+999411,Clostridium colicanis 209318,Clostridium colicanis,,periphery
+999413,[Clostridium] innocuum 2959,Clostridium innocuum,,periphery
+999415,Eggerthia catenaformis OT569,Eggerthia catenaformis,,core
+999419,Parabacteroides johnsonii CL02T12C29,Parabacteroides johnsonii,,periphery
+999423,Selenomonas sp. F0473,Selenomonas sp. F0473,,periphery
+999425,Streptococcus sp. F0442,Streptococcus sp. F0442,,periphery
+999541,Burkholderia gladioli BSR3,Burkholderia gladioli,,periphery
+999547,Leisingera daeponensis DSM23529,Leisingera daeponensis,,core
+999549,Leisingera caerulea DSM24564,Leisingera caerulea,,periphery
+999550,Pseudophaeobacter arcticus DSM23566,Pseudophaeobacter arcticus,,core
+999611,Leisingera aquimarina DSM24565,Leisingera aquimarina,,periphery
+999630,Thermoproteus uzoniensis 768-20,Thermoproteus uzoniensis,,core
+1000565,Methyloversatilis universalis FAM5,Methyloversatilis universalis FAM5,,core
+1000569,Megasphaera sp. UPII 135-E,Megasphaera sp. UPII135E,,periphery
+1000570,Streptococcus anginosus SK52,Streptococcus anginosus SK52,,periphery
+1000588,Streptococcus mitis bv. 2 str. SK95,Streptococcus mitis 2 SK95,,periphery
+1001240,Cryobacterium roopkundense,Cryobacterium roopkundense,,periphery
+1001530,Photobacterium leiognathi subsp. mandapamensis svers.1.1.,Photobacterium leiognathi mandapamensis,,periphery
+1001585,Pseudomonas mendocina NK-01,Pseudomonas mendocina NK01,,core
+1002339,Psychrobacter sp. 1501(2011),Psychrobacter sp. 1501,,periphery
+1002340,Leisingera sp. ANG1,Leisingera sp. ANG1,,periphery
+1002367,Prevotella stercorea DSM18206,Prevotella stercorea,,periphery
+1002672,Candidatus Pelagibacter sp. IMCC9063,Pelagibacter sp. IMCC9063,,periphery
+1002804,Helicobacter bizzozeronii CIII-1,Helicobacter bizzozeronii,,periphery
+1002809,Solibacillus silvestris StLB046,Solibacillus silvestris,,core
+1003195,Streptomyces cattleya NRRL8057,Streptomyces cattleya,,periphery
+1003200,Achromobacter insuavis AXX-A,Achromobacter insuavis,,periphery
+1004149,Mesoflavibacter zeaxanthinifaciens S86,Mesoflavibacter zeaxanth. S86,,periphery
+1004785,Alteromonas macleodii str. 'Black Sea 11',Alteromonas macleodii Black,,periphery
+1005048,Collimonas fungivorans Ter331,Collimonas fungivorans,,core
+1005057,Buchnera aphidicola str. Ua,Buchnera aphidicola Ua,,periphery
+1005058,Gallibacterium anatis UMN179,Gallibacterium anatis,,periphery
+1005090,Buchnera aphidicola str. Ak,Buchnera aphidicola Ak,,periphery
+1005395,Pseudomonas putida CSV86,Pseudomonas putida CSV86,,periphery
+1005704,Streptococcus oralis SK255,Streptococcus oralis SK255,,periphery
+1005705,Streptococcus infantis SK1076,Streptococcus infantis SK1076,,periphery
+1005962,Ogataea parapolymorpha,Ogataea parapolymorpha,,core
+1005994,Trabulsiella guamensis ATCC49490,Trabulsiella guamensis,,core
+1005995,Tatumella ptyseos ATCC33301,Tatumella ptyseos,,periphery
+1005999,Leminorella grimontii ATCC33999,Leminorella grimontii,,core
+1006000,Kluyvera ascorbata ATCC33433,Kluyvera ascorbata,,core
+1006004,Buttiauxella agrestis ATCC33320,Buttiauxella agrestis,,core
+1006006,Metallosphaera cuprina Ar-4,Metallosphaera cuprina,,periphery
+1006581,Mycoplasma gallisepticum S6,Mycoplasma gallisepticum S6,,periphery
+1007096,Oscillibacter ruminantium GH1,Oscillibacter ruminantium,,periphery
+1007103,Paenibacillus elgii B69,Paenibacillus elgii,,core
+1007104,Sphingomonas sp. S17,Sphingomonas sp. S17,,periphery
+1007105,Pusillimonas sp. T7-7,Pusillimonas sp. T77,,core
+1008453,Streptococcus mitis SK1080,Streptococcus mitis SK1080,,periphery
+1008457,Myroides injenensis M09-0166,Myroides injenensis,,periphery
+1008459,Taylorella asinigenitalis MCE3,Taylorella asinigenitalis,,periphery
+1009370,Acetonema longum DSM6540,Acetonema longum,,core
+1009858,Buchnera aphidicola str. G002,Buchnera aphidicola G002,,periphery
+1026882,Methylophaga aminisulfidivorans MP,Methylophaga aminisulfidivorans,,periphery
+1026970,Nannospalax galili,Nannospalax galili,,periphery
+1027273,Endozoicomonas montiporae,Endozoicomonas montiporae,,periphery
+1027292,Sporosarcina newyorkensis 2681,Sporosarcina newyorkensis,,core
+1027371,Gordonia alkanivorans NBRC 16433,Gordonia alkanivorans,,periphery
+1027396,Listeria monocytogenes str. Scott A,Listeria monocytogenes Scott,,periphery
+1028307,Enterobacter aerogenes KCTC 2190,Enterobacter aerogenes,,core
+1028800,Neorhizobium galegae bv. orientalis str. HAMBI 540,Neorhizobium galegae orientalis,,periphery
+1028801,Neorhizobium galegae bv. officinalis bv. officinalis str. HAMBI 1141,Neorhizobium galegae officinalis,,periphery
+1028803,Haemophilus haemolyticus M19501,Haemophilus haemolyticus M19501,,periphery
+1028805,Haemophilus haemolyticus M21621,Haemophilus haemolyticus M21621,,periphery
+1028806,Haemophilus haemolyticus M21639,Haemophilus haemolyticus M21639,,periphery
+1029718,Candidatus Arthromitus sp. SFB-mouse-Japan,Arthromitus sp. SFBmouseJapan,,core
+1029823,Acinetobacter sp. P8-3-8,Acinetobacter sp. P838,,periphery
+1029824,Kocuria rhizophila P7-4,Kocuria rhizophila P74,,periphery
+1030157,Sphingomonas sp. KC8,Sphingomonas sp. KC8,,periphery
+1031288,Caloramator sp. ALD01,Caloramator sp. ALD01,,core
+1031711,Ralstonia solanacearum Po82,Ralstonia solanacearum Po82,,periphery
+1032480,Microlunatus phosphovorus NM-1,Microlunatus phosphovorus,,core
+1033730,Aeromicrobium massiliense JC14,Aeromicrobium massiliense,,periphery
+1033732,Alistipes senegalensis JC50,Alistipes senegalensis,,periphery
+1033733,Anaerococcus senegalensis JC48,Anaerococcus senegalensis,,periphery
+1033734,Bacillus timonensis,Bacillus timonensis,,periphery
+1033736,Brevibacterium senegalense,Brevibacterium senegalense,,core
+1033737,Clostridium senegalense JC122,Clostridium senegalense,,periphery
+1033738,Kurthia sp. Dielmo,Kurthia sp. Dielmo,,core
+1033739,Kurthia massiliensis,Kurthia massiliensis,,periphery
+1033740,Kurthia sp. JC8E,Kurthia sp. JC8E,,periphery
+1033743,Paenibacillus senegalensis JC66,Paenibacillus senegalensis,,periphery
+1033744,Peptoniphilus senegalensis JC140,Peptoniphilus senegalensis,,periphery
+1033802,Salinisphaera shabanensis E1L3A,Salinisphaera shabanensis,,core
+1033806,Halorhabdus tiamatea SARL4B,Halorhabdus tiamatea,,periphery
+1033810,Haloplasma contractile SSD-17B,Haloplasma contractile,,core
+1033837,Lactobacillus kefiranofaciens ZW3,Lactobacillus kefiranofaciens,,periphery
+1033991,Rhizobium leguminosarum bv. trifolii CB782,Rhizobium leguminosarum CB782,,periphery
+1034345,Senegalimassilia anaerobia JC110,Senegalimassilia anaerobia,,periphery
+1034347,Bacillus massiliosenegalensis JC6,Bacillus massiliosenegalensis,,periphery
+1034769,Paenibacillus sp. HW567,Paenibacillus sp. HW567,,periphery
+1034807,Flavobacterium branchiophilum FL-15,Flavobacterium branchiophilum,,periphery
+1034808,Mycoplasma anatis 1340,Mycoplasma anatis,,periphery
+1034809,Staphylococcus lugdunensis N920143,Staphylococcus lugdunensis N920143,,periphery
+1034943,Legionella massiliensis,Legionella massiliensis,,periphery
+1035184,Streptococcus constellatus subsp. pharyngis SK1060,Streptococcus constellatus pharyngis SK1060,,periphery
+1035187,Streptococcus mitis SK569,Streptococcus mitis SK569,,periphery
+1035189,Streptococcus infantis SK970,Streptococcus infantis SK970,,periphery
+1035191,Brevundimonas diminuta 470-4,Brevundimonas diminuta 4704,,periphery
+1035193,Capnocytophaga sp. oral taxon 326 str. F0382,Capnocytophaga sp. F0382,,core
+1035195,Corynebacterium durum F0235,Corynebacterium durum,,periphery
+1035196,Peptostreptococcus anaerobius VPI 4330,Peptostreptococcus anaerobius VPI4330,,periphery
+1035197,Prevotella sp. oral taxon 473 str. F0040,Prevotella sp. F0040,,periphery
+1035308,Dehalobacter sp. FTH1,Dehalobacter sp. FTH1,,periphery
+1035839,Haemophilus sputorum CCUG 13788,Haemophilus sputorum,,periphery
+1036674,Idiomarina sp. A28L,Idiomarina sp. A28L,,periphery
+1037409,Bradyrhizobium japonicum USDA 6,Bradyrhizobium japonicum USDA6,,periphery
+1037410,Mycoplasma columbinum SF7,Mycoplasma columbinum,,periphery
+1038858,Azorhizobium doebereinerae UFLA1-100,Azorhizobium doebereinerae,,periphery
+1038859,Bradyrhizobium elkanii WSM1741,Bradyrhizobium elkanii WSM1741,,periphery
+1038860,Bradyrhizobium elkanii WSM2783,Bradyrhizobium elkanii WSM2783,,periphery
+1038862,Bradyrhizobium japonicum USDA 124,Bradyrhizobium japonicum USDA124,,periphery
+1038866,Bradyrhizobium sp. WSM2793,Bradyrhizobium sp. WSM2793,,periphery
+1038867,Bradyrhizobium sp. WSM3983,Bradyrhizobium sp. WSM3983,,periphery
+1038869,Burkholderia mimosarum LMG 23256,Burkholderia mimosarum,,periphery
+1038922,Pseudomonas fluorescens Q2-87,Pseudomonas fluorescens Q287,,periphery
+1040982,Mesorhizobium loti CJ3sym,Mesorhizobium loti CJ3sym,,periphery
+1040983,Mesorhizobium loti USDA 3471,Mesorhizobium loti USDA3471,,periphery
+1040986,Mesorhizobium sp. WSM3224,Mesorhizobium sp. WSM3224,,periphery
+1040987,Mesorhizobium sp. WSM3626,Mesorhizobium sp. WSM3626,,periphery
+1040989,Bradyrhizobium sp. ARR65,Bradyrhizobium sp. ARR65,,periphery
+1041138,Rhizobium gallicum bv. gallicum R602sp,Rhizobium gallicum,,periphery
+1041139,Rhizobium giardinii bv. giardinii H152,Rhizobium giardinii,,periphery
+1041142,Rhizobium leguminosarum bv. viciae GB30,Rhizobium leguminosarum GB30,,periphery
+1041146,Rhizobium sullae WSM1592,Rhizobium sullae,,periphery
+1041147,Rhizobium leucaenae USDA 9039,Rhizobium leucaenae,,periphery
+1041159,Ensifer sp. WSM1721,Ensifer sp. WSM1721,,periphery
+1041504,Candidatus Arthromitus sp. SFB-rat-Yit,Arthromitus sp. SFBratYit,,periphery
+1041522,Mycobacterium colombiense CECT 3035,Mycobacterium colombiense,,periphery
+1041607,Wickerhamomyces ciferrii,Wickerhamomyces ciferrii,,periphery
+1041826,Flavobacterium columnare ATCC49512,Flavobacterium columnare,,periphery
+1041930,Methanocella conradii HZ254,Methanocella conradii,,core
+1042156,Clostridium sp. SY8519,Clostridium sp. SY8519,,periphery
+1042163,Brevibacillus laterosporus LMG 15441,Brevibacillus laterosporus LMG15441,,core
+1042209,Pseudomonas fluorescens HK44,Pseudomonas fluorescens HK44,,periphery
+1042326,Rhizobium sp. IBUN,Rhizobium sp. IBUN,,periphery
+1042375,Marinobacterium stanieri S30,Marinobacterium stanieri,,periphery
+1042376,Flavobacteriaceae bacterium S85,Flavobacteriaceae bacterium S85,,periphery
+1042377,Microbulbifer agarilyticus S89,Microbulbifer agarilyticus,,periphery
+1042876,Pseudomonas putida S16,Pseudomonas putida S16,,periphery
+1042877,Thermococcus sp. 4557,Thermococcus sp. 4557,,periphery
+1043205,Serinicoccus profundi MCCC 1A05965,Serinicoccus profundi,,core
+1043493,Lysinimicrobium mangrovi,Lysinimicrobium mangrovi,,core
+1045004,Oenococcus kitaharae DSM17330,Oenococcus kitaharae,,periphery
+1045009,Citricoccus sp. CH26A,Citricoccus sp. CH26A,,periphery
+1045854,Weissella koreensis KACC 15510,Weissella koreensis,,periphery
+1045855,Pseudoxanthomonas spadix BD-a59,Pseudoxanthomonas spadix,,periphery
+1045856,Enterobacter cloacae EcWSU1,Enterobacter cloacae EcWSU1,,periphery
+1045858,Brachyspira intermedia PWS/A,Brachyspira intermedia,,core
+1046625,Acinetobacter lwoffii WJ10621,Acinetobacter lwoffii WJ10621,,periphery
+1046627,Bizionia argentinensis JUB59,Bizionia argentinensis,,core
+1046629,Streptococcus salivarius 57.I,Streptococcus salivarius 57I,,periphery
+1046714,Gayadomonas joobiniege G7,Gayadomonas joobiniege,,core
+1046724,Marinobacter lipolyticus BF04_CF-4,Marinobacter lipolyticus BF04CF4,,periphery
+1047013,Aminicenantes bacterium SCGC AAA252-A02,Aminicenantes bacterium AAA252A02,,core
+1047171,Zymoseptoria tritici,Zymoseptoria tritici,,core
+1048339,Sporichthya polymorpha DSM43042,Sporichthya polymorpha,,core
+1048829,Paracoccidioides sp. 'lutzii',Paracoccidioides sp. lutzii,,periphery
+1048830,Mycoplasma iowae 695,Mycoplasma iowae,,periphery
+1048834,Alicyclobacillus acidocaldarius subsp. acidocaldarius Tc-4-1,Alicyclobacillus acidocaldarius Tc41,,periphery
+1048983,Anditalea andensis,Anditalea andensis,,core
+1049564,endosymbiont of Tevnia jerichonana (vent Tica),endosymbiont of Tevnia,,periphery
+1050201,Allobaculum stercoricanis DSM13633,Allobaculum stercoricanis,,core
+1050202,Actinopolyspora mortivallis DSM44261,Actinopolyspora mortivallis,,periphery
+1051006,Propionibacterium acnes SK182B-JCVI,Propionibacterium acnes SK182BJCVI,,core
+1051501,Bacillus mojavensis KCTC 3706,Bacillus mojavensis,,periphery
+1051613,Verticillium alfalfae,Verticillium alfalfae,,periphery
+1051632,Sulfobacillus acidophilus TPY,Sulfobacillus acidophilus,,periphery
+1051646,Vibrio tubiashii ATCC19109,Vibrio tubiashii,,periphery
+1051985,Neisseria weaveri LMG 5135,Neisseria weaveri,,periphery
+1052684,Paenibacillus polymyxa M1,Paenibacillus polymyxa M1,,periphery
+1054213,Acetobacteraceae bacterium AT-5844,Acetobacteraceae bacterium AT5844,,periphery
+1054217,Thermoplasmatales archaeon BRNA1,Thermoplasmatales archaeon,,core
+1054460,Streptococcus pseudopneumoniae IS7493,Streptococcus pseudopneumoniae,,periphery
+1054860,Streptomyces purpureus KA281,Streptomyces purpureus,,periphery
+1055815,Psychrobacter sp. TB67,Psychrobacter sp. TB67,,periphery
+1056495,Caldisphaera lagunensis DSM15908,Caldisphaera lagunensis,,periphery
+1056512,Grimontia indica,Grimontia indica,,periphery
+1056816,Nocardia sp. BMG51109,Nocardia sp. BMG51109,,periphery
+1056820,Teredinibacter turnerae T7902,Teredinibacter turnerae T7902,,periphery
+1057002,Ensifer sp. BR816,Ensifer sp. BR816,,periphery
+1064535,Megasphaera elsdenii DSM20460,Megasphaera elsdenii,,core
+1064537,Brachybacterium paraconglomeratum LC44,Brachybacterium paraconglomeratum,,periphery
+1068978,Amycolatopsis methanolica 239,Amycolatopsis methanolica,,periphery
+1068980,Amycolatopsis nigrescens CSC17Ta-90,Amycolatopsis nigrescens,,periphery
+1069080,Succinispira mobilis DSM6222,Succinispira mobilis,,periphery
+1069533,Streptococcus infantarius subsp. infantarius CJ18,Streptococcus infantarius,,periphery
+1069534,Lactobacillus ruminis ATCC27782,Lactobacillus ruminis ATCC27782,,periphery
+1070319,Candidatus Glomeribacter gigasporarum BEG34,Glomeribacter gigasporarum,,core
+1070774,Halonotius sp. J07HN4,Halonotius sp. J07HN4,,periphery
+1071073,Bacillus sp. NSP22.2,Bacillus sp. NSP222,,periphery
+1071085,haloarchaeon 3A1_DGR,haloarchaeon 3A1DGR,,periphery
+1071379,Tetrapisispora blattae,Tetrapisispora blattae,,periphery
+1071400,Lactobacillus buchneri CD034,Lactobacillus buchneri CD034,,core
+1071679,Burkholderia grimmiae,Burkholderia grimmiae,,periphery
+1072685,Basilea psittacipulmonis DSM24701,Basilea psittacipulmonis,,periphery
+1073999,Cronobacter condimenti 1330,Cronobacter condimenti,,core
+1074451,Lactobacillus curvatus CRL 705,Lactobacillus curvatus,,periphery
+1074488,Brachybacterium squillarum M-6-3,Brachybacterium squillarum,,periphery
+1074889,Blattabacterium sp. (Mastotermes darwiniensis),Blattabacterium sp. MADAR,,periphery
+1075090,Gordonia amarae NBRC 15530,Gordonia amarae,,periphery
+1075399,Blattabacterium sp. (Cryptocercus punctulatus),Blattabacterium sp. Cpu,,periphery
+1076550,Pantoea rwandensis,Pantoea rwandensis,,periphery
+1077144,Dietzia alimentaria 72,Dietzia alimentaria,,periphery
+1077285,Bacteroides faecis MAJ27,Bacteroides faecis,,periphery
+1077972,Arthrobacter globiformis NBRC 12137,Arthrobacter globiformis,,periphery
+1077974,Gordonia effusa NBRC 100432,Gordonia effusa,,periphery
+1078020,Mycobacterium thermoresistibile ATCC19527,Mycobacterium thermoresistibile,,periphery
+1078083,Staphylococcus sp. HGB0015,Staphylococcus sp. HGB0015,,periphery
+1078085,Paenisporosarcina sp. HGH0030,Paenisporosarcina sp. HGH0030,,core
+1079460,Rhizobium mongolense USDA 1844,Rhizobium mongolense,,periphery
+1079986,Streptomyces chartreusis NRRL12338,Streptomyces chartreusis,,periphery
+1080067,Citrobacter sp. S-77,Citrobacter sp. S77,,periphery
+1081640,Sphingomonas elodea ATCC31461,Sphingomonas elodea,,periphery
+1081644,Candidatus Aquiluna sp. IMCC13023,Aquiluna sp. IMCC13023,,periphery
+1082705,Lonsdalea quercina subsp. quercina,Lonsdalea quercina,,core
+1082931,Pelagibacterium halotolerans B2,Pelagibacterium halotolerans,,core
+1082932,Agrobacterium tumefaciens CCNWGS0286,Agrobacterium tumefaciens CCNWGS0286,,periphery
+1082933,Mesorhizobium amorphae CCNWGS0123,Mesorhizobium amorphae,,periphery
+1085623,Glaciecola nitratireducens FR1064,Glaciecola nitratireducens,,periphery
+1086011,Flavobacterium frigoris PS1,Flavobacterium frigoris,,periphery
+1087448,Exiguobacterium antarcticum B7,Exiguobacterium antarcticum,,periphery
+1087481,Paenibacillus peoriae KCTC 3763,Paenibacillus peoriae,,periphery
+1088721,Novosphingobium pentaromativorans US6-1,Novosphingobium pentaromativorans,,periphery
+1088868,Commensalibacter intestini A911,Commensalibacter intestini,,periphery
+1088869,Gluconobacter morbifer G707,Gluconobacter morbifer,,periphery
+1089439,Fangia hongkongensis FSC776,Fangia hongkongensis,,core
+1089447,Aggregatibacter actinomycetemcomitans RhAA1,Aggregatibacter actinomycetemcomitans RhAA1,,periphery
+1089453,Gordonia sputi NBRC 100414,Gordonia sputi,,periphery
+1089455,Mobilicoccus pelagius NBRC 104925,Mobilicoccus pelagius,,periphery
+1089544,Amycolatopsis benzoatilytica AK 16/65,Amycolatopsis benzoatilytica,,periphery
+1089545,Amycolatopsis balhimycina FH 1894,Amycolatopsis balhimycina,,periphery
+1089546,Actinopolyspora halophila DSM43834,Actinopolyspora halophila,,periphery
+1089547,Rudanella lutea DSM19387,Rudanella lutea,,core
+1089548,Thermicanus aegyptius DSM12793,Thermicanus aegyptius,,core
+1089549,Haloglycomyces albus DSM45210,Haloglycomyces albus,,core
+1089550,Salisaeta longa DSM21114,Salisaeta longa,,periphery
+1089551,Geminicoccus roseus DSM18922,Geminicoccus roseus,,core
+1089552,Rhodovibrio salinarum DSM9154,Rhodovibrio salinarum,,core
+1089553,Thermacetogenium phaeum DSM12270,Thermacetogenium phaeum,,core
+1090318,Sphingomonas phyllosphaerae 5.2,Sphingomonas phyllosphaerae 52,,periphery
+1090319,Sphingomonas phyllosphaerae FA2,Sphingomonas phyllosphaerae FA2,,periphery
+1090320,Sphingomonas melonis DAPP-PG 224,Sphingomonas melonis,,periphery
+1094184,Xanthomonas campestris pv. musacearum NCPPB 4379,Xanthomonas campestris musacearum,,periphery
+1094466,Flavobacterium indicum GPTSA100-9,Flavobacterium indicum,,periphery
+1094489,Bartonella australis Aust/NH1,Bartonella australis,,periphery
+1094491,Bartonella bovis 91-4,Bartonella bovis,,periphery
+1094496,Bartonella schoenbuchensis m07a,Bartonella schoenbuchensis,,periphery
+1094497,Bartonella vinsonii subsp. berkhoffii str. Winnie,Bartonella vinsonii berkhoffii,,periphery
+1094508,Thermoanaerobacterium saccharolyticum JW/SL-YS485,Thermoanaerobacterium saccharolyticum,,core
+1094551,Bartonella alsatica IBS 382,Bartonella alsatica,,periphery
+1094553,Bartonella doshiae NCTC 12862,Bartonella doshiae,,periphery
+1094556,Bartonella rattimassiliensis 15908,Bartonella rattimassiliensis,,periphery
+1094557,Bartonella melophagi K-2C,Bartonella melophagi,,periphery
+1094558,Bartonella tamiae Th239,Bartonella tamiae,,periphery
+1094560,Bartonella taylorii 8TBB,Bartonella taylorii,,periphery
+1094561,Bartonella vinsonii subsp. arupensis Pm136co,Bartonella vinsonii arupensis,,core
+1094563,Bartonella washoensis Sb944nv,Bartonella washoensis,,periphery
+1094715,Fluoribacter dumoffii NY 23,Fluoribacter dumoffii,,periphery
+1094755,Bartonella sp. DB5-6,Bartonella sp. DB56,,core
+1094980,Methanolobus psychrophilus R15,Methanolobus psychrophilus,,core
+1095726,Streptococcus sp. SK140,Streptococcus sp. SK140,,periphery
+1095727,Streptococcus sp. SK643,Streptococcus sp. SK643,,periphery
+1095737,Streptococcus mitis SK579,Streptococcus mitis SK579,,periphery
+1095738,Streptococcus oralis SK1074,Streptococcus oralis SK1074,,periphery
+1095743,Haemophilus paraphrohaemolyticus HK411,Haemophilus paraphrohaemolyticus,,periphery
+1095747,Fusobacterium necrophorum subsp. funduliforme ATCC51357,Fusobacterium necrophorum funduliforme,,periphery
+1095749,Pasteurella bettyae CCUG 2042,Pasteurella bettyae,,periphery
+1095750,Lachnoanaerobaculum saburreum F0468,Lachnoanaerobaculum saburreum F0468,,periphery
+1095752,Prevotella sp. oral taxon 306 str. F0472,Prevotella sp. F0472,,periphery
+1095767,Cellulomonas massiliensis JC225,Cellulomonas massiliensis,,periphery
+1095769,Herbaspirillum massiliense JC206,Herbaspirillum massiliense,,periphery
+1095770,Peptoniphilus timonensis JC401,Peptoniphilus timonensis,,periphery
+1095772,Timonella senegalensis JC301,Timonella senegalensis,,core
+1096546,Methylobacterium sp. GXF4,Methylobacterium sp. GXF4,,periphery
+1096756,Arthrobacter sp. PAO19,Arthrobacter sp. PAO19,,periphery
+1096769,Candidatus Pelagibacter ubique HIMB083,Pelagibacter ubique HIMB083,,periphery
+1096930,Novosphingobium lindaniclasticum LE124,Novosphingobium lindaniclasticum,,periphery
+1097668,Burkholderia sp. YI23,Burkholderia sp. YI23,,core
+1100720,Limnohabitans sp. Rim28,Limnohabitans sp. Rim28,,periphery
+1100721,Limnohabitans sp. Rim47,Limnohabitans sp. Rim47,,core
+1101188,Arthrobacter sp. MA-N2,Arthrobacter sp. MAN2,,periphery
+1101189,Paracoccus sp. N5,Paracoccus sp. N5,,periphery
+1101190,Methylopila sp. M107,Methylopila sp. M107,,periphery
+1101191,Methylobacterium sp. 10,Methylobacterium sp. 10,,periphery
+1101192,Methylobacterium sp. 77,Methylobacterium sp. 77,,periphery
+1101195,Methylophilaceae bacterium 11,Methylophilaceae bacterium 11,,periphery
+1104324,Pyrobaculum sp. 1860,Pyrobaculum sp. 1860,,periphery
+1104325,Enterococcus faecium NRRL B-2354,Enterococcus faecium NRRLB2354,,core
+1105029,Actinomyces sp. ICM39,Actinomyces sp. ICM39,,core
+1105031,Clostridium sp. MSTE9,Clostridium sp. MSTE9,,periphery
+1105110,Rickettsia australis str. Cutlack,Rickettsia australis,,periphery
+1105367,Paenirhodobacter enshiensis,Paenirhodobacter enshiensis,,core
+1107311,Flavobacterium enshiense DK69,Flavobacterium enshiense,,periphery
+1108045,Gordonia rhizosphera NBRC 16068,Gordonia rhizosphera,,periphery
+1108849,Penicillium rubens,Penicillium rubens,,periphery
+1109445,Pseudomonas stutzeri SDM-LAC,Pseudomonas stutzeri SDMLAC,,periphery
+1110502,Tistrella mobilis KA081020-065,Tistrella mobilis,,core
+1110697,Nocardia asteroides NBRC 15531,Nocardia asteroides,,periphery
+1111069,Thermus sp. CCB_US3_UF1,Thermus sp. CCBUS3UF1,,periphery
+1111121,Atopobium sp. BV3Ac4,Atopobium sp. BV3Ac4,,periphery
+1111131,Propionimicrobium sp. BV2F7,Propionimicrobium sp. BV2F7,,periphery
+1111134,Peptoniphilus sp. BV3C26,Peptoniphilus sp. BV3C26,,periphery
+1111135,Coriobacteriaceae bacterium BV3Ac1,Coriobacteriaceae bacterium BV3Ac1,,periphery
+1111454,Megasphaera sp. BV3C16-1,Megasphaera sp. BV3C161,,periphery
+1111479,Alicyclobacillus pomorum DSM14955,Alicyclobacillus pomorum,,core
+1111728,Budvicia aquatica DSM5075,Budvicia aquatica,,core
+1111729,Corynebacterium sputi DSM45148,Corynebacterium sputi,,periphery
+1111730,Flavobacterium antarcticum DSM19726,Flavobacterium antarcticum,,periphery
+1111732,Ignatzschineria larvae DSM13226,Ignatzschineria larvae,,periphery
+1112204,Gordonia polyisoprenivorans VH2,Gordonia polyisoprenivorans,,core
+1112209,Psychrobacter sp. PAMC 21119,Psychrobacter sp. PAMC21119,,core
+1112212,Sphingomonas echinoides ATCC14820,Sphingomonas echinoides,,periphery
+1112214,Sphingomonas sp. PAMC 26605,Sphingomonas sp. PAMC26605,,periphery
+1112216,Sphingomonas sp. PAMC 26617,Sphingomonas sp. PAMC26617,,periphery
+1112217,Pseudomonas psychrotolerans L19,Pseudomonas psychrotolerans,,periphery
+1112274,Methylophilus sp. 5,Methylophilus sp. 5,,periphery
+1114856,Natronorubrum tibetense GA33,Natronorubrum tibetense,,periphery
+1114922,Citrobacter farmeri GTC 1319,Citrobacter farmeri,,periphery
+1114959,Saccharomonospora azurea SZMC 14600,Saccharomonospora azurea,,periphery
+1114964,Sphingobium baderi LL03,Sphingobium baderi,,periphery
+1114965,Streptococcus parasanguinis FW213,Streptococcus parasanguinis FW213,,periphery
+1114970,Pseudomonas fluorescens F113,Pseudomonas fluorescens F113,,periphery
+1114972,Lactobacillus rossiae DSM15814,Lactobacillus rossiae,,periphery
+1115512,Escherichia hermannii NBRC 105704,Escherichia hermannii,,periphery
+1115515,Escherichia vulneris NBRC 102420,Escherichia vulneris,,periphery
+1115632,Arthrobacter sp. 31Y,Arthrobacter sp. 31Y,,periphery
+1115803,Actinomyces naeslundii str. Howell 279,Actinomyces naeslundii,,periphery
+1116231,Streptococcus macedonicus ACA-DC 198,Streptococcus macedonicus,,periphery
+1116232,Streptomyces acidiscabies 84-104,Streptomyces acidiscabies,,periphery
+1116369,Hoeflea sp. 108,Hoeflea sp. 108,,periphery
+1116375,Vibrio sp. EJY3,Vibrio sp. EJY3,,periphery
+1116472,Methyloglobulus morosus KoM1,Methyloglobulus morosus,,periphery
+1117108,Paenibacillus alvei TS-15,Paenibacillus alvei,,periphery
+1117314,Pseudoalteromonas citrea NCIMB 1889,Pseudoalteromonas citrea,,core
+1117315,Pseudoalteromonas haloplanktis ATCC14393,Pseudoalteromonas haloplanktis ATCC14393,,periphery
+1117318,Pseudoalteromonas rubra ATCC29570,Pseudoalteromonas rubra,,core
+1117319,Pseudoalteromonas spongiae UST010723-006,Pseudoalteromonas spongiae,,core
+1117379,Bacillus bataviensis LMG 21833,Bacillus bataviensis,,periphery
+1117644,Mycoplasma canis PG 14,Mycoplasma canis,,periphery
+1117647,Simiduia agarivorans SA1,Simiduia agarivorans,,core
+1117943,Sinorhizobium fredii HH103,Sinorhizobium fredii HH103,,periphery
+1117958,Pseudomonas extremaustralis 14-3 substr. 14-3b,Pseudomonas extremaustralis,,periphery
+1118054,Brevibacillus massiliensis,Brevibacillus massiliensis,,periphery
+1118055,Anaerococcus sp. PH9,Anaerococcus sp. PH9,,core
+1118057,Peptoniphilus grossensis ph5,Peptoniphilus grossensis,,periphery
+1118058,Actinomyces sp. ph3,Actinomyces sp. ph3,,periphery
+1118059,Kallipyga massiliensis ph2,Kallipyga massiliensis,,periphery
+1118060,Enorma massiliensis phI,Enorma massiliensis,,periphery
+1118153,Halomonas sp. GFAJ-1,Halomonas sp. GFAJ1,,periphery
+1118235,Stenotrophomonas maltophilia PML168,Stenotrophomonas maltophilia PML168,,periphery
+1118964,Mycoplasma hyorhinis SK76,Mycoplasma hyorhinis SK76,,periphery
+1120705,Sphingopyxis sp. LC363,Sphingopyxis sp. LC363,,periphery
+1120746,Bacterium sp. MS4,Bacterium sp. MS4,,core
+1120792,Methylopila sp. 73B,Methylopila sp. 73B,,core
+1120797,Mycobacterium sp. 141,Mycobacterium sp. 141,,periphery
+1120917,Acaricomes phytoseiuli DSM14247,Acaricomes phytoseiuli,,periphery
+1120919,Acetobacter nitrogenifigens DSM23921,Acetobacter nitrogenifigens,,periphery
+1120925,Acinetobacter bouvetii DSM14964,Acinetobacter bouvetii,,periphery
+1120931,Actinobacillus capsulatus DSM19761,Actinobacillus capsulatus,,periphery
+1120933,Actinobaculum urinale DSM15805,Actinobaculum urinale,,periphery
+1120934,Actinokineospora enzanensis DSM44649,Actinokineospora enzanensis,,periphery
+1120936,Actinomadura atramentaria DSM43919,Actinomadura atramentaria,,periphery
+1120941,Actinomyces dentalis DSM19115,Actinomyces dentalis,,periphery
+1120942,Actinomyces georgiae DSM6843,Actinomyces georgiae,,periphery
+1120944,Actinomyces israelii DSM43320,Actinomyces israelii,,periphery
+1120945,Actinomyces neuii subsp. neuii DSM8576,Actinomyces neuii DSM8576,,periphery
+1120946,Actinomyces suimastitidis DSM15538,Actinomyces suimastitidis,,periphery
+1120947,Actinomyces vaccimaxillae DSM15804,Actinomyces vaccimaxillae,,periphery
+1120948,Actinomycetospora chiangmaiensis DSM45062,Actinomycetospora chiangmaiensis,,periphery
+1120949,Actinoplanes globisporus DSM43857,Actinoplanes globisporus,,periphery
+1120950,Actinopolymorpha alba DSM45243,Actinopolymorpha alba,,periphery
+1120951,Aequorivita capsosiphonis DSM23843,Aequorivita capsosiphonis,,periphery
+1120953,Aestuariibacter salexigens DSM15300,Aestuariibacter salexigens,,core
+1120954,Aestuariimicrobium kwangyangense DSM21549,Aestuariimicrobium kwangyangense,,periphery
+1120956,Afifella pfennigii DSM17143,Afifella pfennigii,,periphery
+1120958,Agrococcus lahaulensis DSM17612,Agrococcus lahaulensis,,periphery
+1120959,Agromyces italicus DSM16388,Agromyces italicus,,core
+1120960,Agromyces subbeticus DSM16689,Agromyces subbeticus,,periphery
+1120963,Algicola sagamiensis DSM14643,Algicola sagamiensis,,core
+1120965,Algoriphagus mannitolivorans DSM15301,Algoriphagus mannitolivorans,,periphery
+1120966,Algoriphagus marincola DSM16067,Algoriphagus marincola DSM16067,,periphery
+1120968,Algoriphagus vanfongensis DSM17529,Algoriphagus vanfongensis,,periphery
+1120970,Aliagarivorans taiwanensis DSM22990,Aliagarivorans taiwanensis,,core
+1120971,Alicyclobacillus contaminans DSM17975,Alicyclobacillus contaminans,,periphery
+1120972,Alicyclobacillus herbarius DSM13609,Alicyclobacillus herbarius,,periphery
+1120973,Alicyclobacillus pohliae DSM22757,Alicyclobacillus pohliae,,periphery
+1120977,Alkanindiges illinoisensis DSM15370,Alkanindiges illinoisensis,,core
+1120978,Allofustis seminis DSM15817,Allofustis seminis,,core
+1120979,Alloscardovia omnicolens DSM21503,Alloscardovia omnicolens,,core
+1120980,Alysiella crassa DSM2578,Alysiella crassa,,core
+1120983,Amorphus coralli DSM19760,Amorphus coralli,,core
+1120985,Anaeroarcus burkinensis DSM6283,Anaeroarcus burkinensis,,core
+1120988,Anaerobiospirillum succiniciproducens DSM6400,Anaerobiospirillum succiniciproducens,,periphery
+1120998,Anaerovorax odorimutans DSM5092,Anaerovorax odorimutans,,periphery
+1120999,Andreprevotia chitinilytica DSM18519,Andreprevotia chitinilytica,,core
+1121004,Aquaspirillum serpens DSM68,Aquaspirillum serpens,,core
+1121007,Aquimarina muelleri DSM19832,Aquimarina muelleri,,periphery
+1121011,Arenibacter certesii DSM19833,Arenibacter certesii,,periphery
+1121012,Arenibacter latericius DSM15913,Arenibacter latericius,,periphery
+1121013,Arenimonas composti TR7-09,Arenimonas composti,,periphery
+1121015,Arenimonas oryziterrae DSM21050,Arenimonas oryziterrae,,periphery
+1121017,Arsenicicoccus bolidensis DSM15745,Arsenicicoccus bolidensis,,periphery
+1121019,Arthrobacter castelli DSM16402,Arthrobacter castelli,,periphery
+1121020,Arthrobacter sanguinis DSM21259,Arthrobacter sanguinis,,periphery
+1121022,Asticcacaulis benevestitus DSM16100,Asticcacaulis benevestitus,,periphery
+1121024,Atopococcus tabaci DSM17538,Atopococcus tabaci,,core
+1121028,Aureimonas ureilytica DSM18598,Aureimonas ureilytica,,periphery
+1121033,Azospirillum halopraeferens DSM3675,Azospirillum halopraeferens,,core
+1121035,Azovibrio restrictus DSM23866,Azovibrio restrictus,,core
+1121085,Bacillus aidingensis DSM18341,Bacillus aidingensis,,periphery
+1121087,Bacillus chagannorensis DSM18086,Bacillus chagannorensis,,periphery
+1121090,Bacillus fordii DSM16014,Bacillus fordii,,periphery
+1121091,Bacillus gelatini DSM15865,Bacillus gelatini,,core
+1121094,Bacteroides barnesiae DSM18169,Bacteroides barnesiae,,periphery
+1121097,Bacteroides graminisolvens DSM19988,Bacteroides graminisolvens,,periphery
+1121098,Bacteroides massiliensis B84634,Bacteroides massiliensis B84634,,periphery
+1121100,Bacteroides pyogenes DSM20611,Bacteroides pyogenes DSM20611,,periphery
+1121101,Bacteroides salyersiae WAL 10018,Bacteroides salyersiae,,periphery
+1121104,Balneola vulgaris DSM17893,Balneola vulgaris,,periphery
+1121105,Bavariicoccus seileri DSM19936,Bavariicoccus seileri,,core
+1121106,Belnapia moabensis DSM16746,Belnapia moabensis,,periphery
+1121115,Blautia wexlerae DSM19850,Blautia wexlerae,,periphery
+1121116,Brachymonas chironomi DSM19884,Brachymonas chironomi,,core
+1121121,Brevibacillus laterosporus DSM25,Brevibacillus laterosporus DSM25,,periphery
+1121123,Brevundimonas aveniformis DSM17977,Brevundimonas aveniformis,,periphery
+1121124,Brevundimonas bacteroides DSM4726,Brevundimonas bacteroides,,periphery
+1121127,Burkholderia nodosa DSM21604,Burkholderia nodosa,,periphery
+1121129,Butyricimonas synergistica DSM23225,Butyricimonas synergistica,,core
+1121267,Campylobacter cuniculorum DSM23162,Campylobacter cuniculorum,,periphery
+1121271,Gemmobacter nectariphilus DSM15620,Gemmobacter nectariphilus,,core
+1121272,Catelliglobosispora koreensis DSM44566,Catelliglobosispora koreensis,,periphery
+1121285,Chryseobacterium caeni DSM17710,Chryseobacterium caeni,,periphery
+1121286,Chryseobacterium daeguense DSM19388,Chryseobacterium daeguense,,periphery
+1121287,Chryseobacterium gregarium DSM19109,Chryseobacterium gregarium,,periphery
+1121288,Chryseobacterium palustre DSM21579,Chryseobacterium palustre,,periphery
+1121289,Clostridiisalibacter paucivorans DSM22131,Clostridiisalibacter paucivorans,,core
+1121296,[Clostridium] aminophilum DSM10710,Clostridium aminophilum,,periphery
+1121324,[Clostridium] litorale DSM5388,Clostridium litorale,,periphery
+1121333,[Clostridium] saccharogumia DSM17460,Clostridium saccharogumia,,core
+1121334,[Clostridium] sporosphaeroides DSM1294,Clostridium sporosphaeroides,,periphery
+1121335,[Clostridium] stercorarium subsp. stercorarium DSM8532,Clostridium stercorarium,,periphery
+1121342,Clostridium tyrobutyricum DSM2637,Clostridium tyrobutyricum,,periphery
+1121344,[Clostridium] viride DSM6836,Clostridium viride,,periphery
+1121346,Cohnella laeviribosi DSM21336,Cohnella laeviribosi,,core
+1121351,Conchiformibius kuhniae DSM17694,Conchiformibius kuhniae,,periphery
+1121352,Conchiformibius steedae DSM2580,Conchiformibius steedae,,core
+1121353,Corynebacterium callunae DSM20147,Corynebacterium callunae,,periphery
+1121354,Corynebacterium capitovis DSM44611,Corynebacterium capitovis,,periphery
+1121355,Corynebacterium caspium DSM44850,Corynebacterium caspium,,periphery
+1121356,Corynebacterium ciconiae DSM44920,Corynebacterium ciconiae,,periphery
+1121360,Corynebacterium freiburgense DSM45254,Corynebacterium freiburgense,,periphery
+1121362,Corynebacterium halotolerans YIM 70093,Corynebacterium halotolerans,,periphery
+1121363,Corynebacterium lubricantis DSM45231,Corynebacterium lubricantis,,periphery
+1121364,Corynebacterium massiliense DSM45435,Corynebacterium massiliense,,periphery
+1121365,Corynebacterium mastitidis DSM44356,Corynebacterium mastitidis,,periphery
+1121366,Corynebacterium pilosum DSM20521,Corynebacterium pilosum,,periphery
+1121367,Corynebacterium propinquum DSM44285,Corynebacterium propinquum,,periphery
+1121370,Corynebacterium ulceribovis DSM45146,Corynebacterium ulceribovis,,periphery
+1121372,Gryllotalpicola ginsengisoli DSM22003,Gryllotalpicola ginsengisoli,,periphery
+1121373,Cytophaga aurantiaca DSM3654,Cytophaga aurantiaca,,periphery
+1121374,Dasania marina DSM21967,Dasania marina,,core
+1121377,Deinococcus apachensis DSM19763,Deinococcus apachensis,,periphery
+1121378,Deinococcus aquatilis DSM23025,Deinococcus aquatilis,,periphery
+1121380,Deinococcus frigens DSM12807,Deinococcus frigens,,periphery
+1121381,Deinococcus marmoris DSM12784,Deinococcus marmoris,,periphery
+1121382,Deinococcus misasensis DSM22328,Deinococcus misasensis,,periphery
+1121385,Demetria terragena DSM11295,Demetria terragena,,periphery
+1121396,Desulfobacter curvatus DSM3379,Desulfobacter curvatus,,core
+1121403,Desulfobulbus japonicus DSM18378,Desulfobulbus japonicus,,periphery
+1121405,Desulfococcus multivorans DSM2059,Desulfococcus multivorans,,periphery
+1121406,Desulfocurvus vexinensis DSM17965,Desulfocurvus vexinensis,,periphery
+1121413,Desulfonatronovibrio hydrogenovorans DSM9292,Desulfonatronovibrio hydrogenovorans,,periphery
+1121422,Desulfotomaculum alcoholivorax DSM16058,Desulfotomaculum alcoholivorax,,periphery
+1121423,Desulfotomaculum alkaliphilum DSM12257,Desulfotomaculum alkaliphilum,,periphery
+1121428,Desulfotomaculum hydrothermale Lam5,Desulfotomaculum hydrothermale,,periphery
+1121430,Desulfotomaculum thermocisternum DSM10259,Desulfotomaculum thermocisternum,,periphery
+1121434,Desulfovibrio acrylicus DSM10141,Desulfovibrio acrylicus,,periphery
+1121438,Desulfovibrio alcoholivorans DSM5433,Desulfovibrio alcoholivorans,,periphery
+1121439,Desulfovibrio alkalitolerans DSM16529,Desulfovibrio alkalitolerans,,periphery
+1121440,Desulfovibrio aminophilus DSM12254,Desulfovibrio aminophilus,,periphery
+1121441,Desulfovibrio bastinii DSM16055,Desulfovibrio bastinii,,periphery
+1121445,Desulfovibrio desulfuricans subsp. desulfuricans DSM642,Desulfovibrio desulfuricans DSM642,,periphery
+1121447,Desulfovibrio frigidus DSM17176,Desulfovibrio frigidus,,periphery
+1121448,Desulfovibrio gigas DSM1382,Desulfovibrio gigas,,periphery
+1121451,Desulfovibrio hydrothermalis AM13,Desulfovibrio hydrothermalis,,periphery
+1121456,Desulfovibrio longus DSM6739,Desulfovibrio longus,,periphery
+1121459,Desulfovibrio oxyclinae DSM11498,Desulfovibrio oxyclinae,,periphery
+1121468,Desulfovirgula thermocuniculi DSM16036,Desulfovirgula thermocuniculi,,core
+1121472,Desulfurispora thermophila DSM16022,Desulfurispora thermophila,,core
+1121479,Donghicola xiamenensis DSM18339,Donghicola xiamenensis,,core
+1121481,Dyadobacter alkalitolerans DSM23607,Dyadobacter alkalitolerans,,periphery
+1121859,Echinicola pacifica DSM19836,Echinicola pacifica,,periphery
+1121861,Elioraea tepidiphila DSM17972,Elioraea tepidiphila,,periphery
+1121864,Enterococcus cecorum DSM20682,Enterococcus cecorum,,periphery
+1121865,Enterococcus columbae DSM7374,Enterococcus columbae,,periphery
+1121866,Enterorhabdus mucosicola DSM19490,Enterorhabdus mucosicola,,periphery
+1121870,Epilithonimonas tenax DSM16811,Epilithonimonas tenax,,periphery
+1121871,Eremococcus coleocola DSM15696,Eremococcus coleocola DSM15696,,periphery
+1121874,Erysipelothrix tonsillarum DSM14972,Erysipelothrix tonsillarum,,periphery
+1121875,Eudoraea adriatica DSM19308,Eudoraea adriatica,,core
+1121877,Ferrimicrobium acidiphilum DSM19497,Ferrimicrobium acidiphilum,,periphery
+1121878,Ferrimonas futtsuensis DSM18154,Ferrimonas futtsuensis,,periphery
+1121887,Flavobacterium daejeonense DSM17708,Flavobacterium daejeonense,,periphery
+1121889,Flavobacterium filum DSM17961,Flavobacterium filum,,periphery
+1121890,Flavobacterium frigidarium DSM17623,Flavobacterium frigidarium,,periphery
+1121895,Flavobacterium rivuli WB 3.3-2,Flavobacterium rivuli,,periphery
+1121896,Flavobacterium sasangense DSM21067,Flavobacterium sasangense,,periphery
+1121897,Flavobacterium soli DSM19725,Flavobacterium soli,,periphery
+1121898,Flavobacterium subsaxonicum WB 4.1-42,Flavobacterium subsaxonicum,,periphery
+1121899,Flavobacterium suncheonense GH29-5,Flavobacterium suncheonense,,periphery
+1121904,Flexithrix dorotheae DSM6795,Flexithrix dorotheae,,periphery
+1121912,Gelidibacter mesophilus DSM14095,Gelidibacter mesophilus,,core
+1121914,Gemella cuniculi DSM15828,Gemella cuniculi,,periphery
+1121918,Geopsychrobacter electrodiphilus DSM16401,Geopsychrobacter electrodiphilus,,periphery
+1121920,Geothrix fermentans DSM14018,Geothrix fermentans,,core
+1121921,Gilvimarinus chinensis DSM19667,Gilvimarinus chinensis,,core
+1121923,Glaciecola punicea DSM14233,Glaciecola punicea,,periphery
+1121924,Glaciibacter superstes DSM21135,Glaciibacter superstes,,periphery
+1121926,Glycomyces arizonensis DSM44726,Glycomyces arizonensis,,periphery
+1121927,Gordonia hirsuta DSM44140,Gordonia hirsuta,,periphery
+1121928,Gordonia shandongensis DSM45094,Gordonia shandongensis,,periphery
+1121929,Gracilibacillus lacisalsi DSM19029,Gracilibacillus lacisalsi,,core
+1121930,Gracilimonas tropica DSM19535,Gracilimonas tropica,,periphery
+1121931,Gramella echinicola DSM19838,Gramella echinicola,,periphery
+1121933,Granulicoccus phenolivorans DSM17626,Granulicoccus phenolivorans,,periphery
+1121934,Gulosibacter molinativorax DSM13485,Gulosibacter molinativorax,,periphery
+1121935,Hahella ganghwensis DSM17046,Hahella ganghwensis,,periphery
+1121936,Halalkalibacillus halophilus DSM18494,Halalkalibacillus halophilus,,core
+1121937,Haliea salexigens DSM19537,Haliea salexigens,,core
+1121938,Halobacillus kuroshimensis DSM18393,Halobacillus kuroshimensis,,periphery
+1121939,Halomonas anticariensis FP35,Halomonas anticariensis,,periphery
+1121940,Halomonas halocynthiae DSM14573,Halomonas halocynthiae,,periphery
+1121943,Halomonas lutea DSM23508,Halomonas lutea,,periphery
+1121945,Halorubrum ezzemoulense DSM17463,Halorubrum ezzemoulense,,periphery
+1121946,Hamadaea tsunoensis DSM44101,Hamadaea tsunoensis,,periphery
+1121947,Helcococcus sueciensis DSM17243,Helcococcus sueciensis,,periphery
+1121948,Hellea balneolensis DSM19091,Hellea balneolensis,,periphery
+1121949,Henriciella marina DSM19595,Henriciella marina,,periphery
+1121952,Humibacter albus DSM18994,Humibacter albus,,periphery
+1121957,Hymenobacter norwichensis DSM15439,Hymenobacter norwichensis,,periphery
+1122128,Jeotgalicoccus marinus DSM19772,Jeotgalicoccus marinus,,periphery
+1122129,Jeotgalicoccus psychrophilus DSM19085,Jeotgalicoccus psychrophilus,,periphery
+1122130,Jonesia quinghaiensis DSM15701,Jonesia quinghaiensis,,periphery
+1122132,Kaistia granuli DSM23481,Kaistia granuli,,periphery
+1122134,Kangiella aquimarina DSM16071,Kangiella aquimarina,,periphery
+1122135,Kiloniella laminariae DSM19542,Kiloniella laminariae,,core
+1122137,Kordiimonas gwangyangensis DSM19435,Kordiimonas gwangyangensis,,core
+1122138,Kribbella catacumbae DSM19601,Kribbella catacumbae,,periphery
+1122139,Kushneria aurantia DSM21353,Kushneria aurantia,,periphery
+1122143,Lacticigenium naphtae DSM19658,Lacticigenium naphtae,,core
+1122146,Lactobacillus ceti DSM22408,Lactobacillus ceti,,periphery
+1122147,Lactobacillus harbinensis DSM16991,Lactobacillus harbinensis,,periphery
+1122149,Lactobacillus malefermentans DSM5705,Lactobacillus malefermentans,,periphery
+1122152,Lactobacillus psittaci DSM15354,Lactobacillus psittaci,,periphery
+1122164,Legionella lansingensis DSM19556,Legionella lansingensis,,periphery
+1122165,Legionella moravica DSM19234,Legionella moravica,,periphery
+1122169,Legionella shakespearei DSM23087,Legionella shakespearei,,periphery
+1122172,Leptotrichia shahii DSM19757,Leptotrichia shahii,,periphery
+1122173,Leptotrichia trevisanii DSM22070,Leptotrichia trevisanii,,periphery
+1122175,Leucobacter chironomi DSM19883,Leucobacter chironomi,,periphery
+1122176,Lewinella cohaerens DSM23179,Lewinella cohaerens,,core
+1122179,Lewinella persica DSM23188,Lewinella persica,,periphery
+1122180,Loktanella hongkongensis DSM17492,Loktanella hongkongensis,,periphery
+1122182,Longispora albida DSM44784,Longispora albida,,periphery
+1122185,Lysobacter concretionis Ko07,Lysobacter concretionis,,periphery
+1122194,Marinimicrobium agarilyticum DSM16975,Marinimicrobium agarilyticum,,core
+1122197,Marinobacter daepoensis DSM16072,Marinobacter daepoensis,,periphery
+1122201,Marinobacterium litorale DSM23545,Marinobacterium litorale,,periphery
+1122207,Marinomonas ushuaiensis DSM15871,Marinomonas ushuaiensis,,periphery
+1122211,Marinospirillum insulare DSM21763,Marinospirillum insulare,,periphery
+1122212,Marinospirillum minutulum DSM6287,Marinospirillum minutulum,,core
+1122214,Martelella mediterranea DSM17316,Martelella mediterranea,,periphery
+1122216,Megamonas hypermegale DSM1672,Megamonas hypermegale,,periphery
+1122217,Megamonas rupellensis DSM19944,Megamonas rupellensis,,core
+1122218,Meganema perideroedes DSM15528,Meganema perideroedes,,core
+1122221,Meiothermus cerbereus DSM11376,Meiothermus cerbereus,,periphery
+1122222,Meiothermus taiwanensis DSM14542,Meiothermus taiwanensis,,periphery
+1122223,Meiothermus timidus DSM17022,Meiothermus timidus,,periphery
+1122225,Mesoflavibacter zeaxanthinifaciens DSM18436,Mesoflavibacter zeaxanth. DSM18436,,core
+1122226,Mesonia mobilis DSM19841,Mesonia mobilis,,core
+1122228,Metascardovia criceti DSM17774,Metascardovia criceti,,periphery
+1122236,Methylophilus methylotrophus DSM46235,Methylophilus methylotrophus,,periphery
+1122237,Microbacterium gubbeenense DSM15944,Microbacterium gubbeenense,,periphery
+1122238,Microbacterium indicum DSM19969,Microbacterium indicum,,periphery
+1122239,Microbacterium luticocti DSM19459,Microbacterium luticocti,,periphery
+1122243,Moraxella boevrei DSM14165,Moraxella boevrei,,periphery
+1122244,Moraxella caprae DSM19149,Moraxella caprae,,core
+1122247,Mycobacterium hassiacum DSM44199,Mycobacterium hassiacum,,periphery
+1122599,Neptunomonas japonica DSM18939,Neptunomonas japonica,,core
+1122602,Nesterenkonia alba DSM19423,Nesterenkonia alba,,periphery
+1122603,Nevskia ramosa DSM11499,Nevskia ramosa,,periphery
+1122604,Nevskia soli DSM19509,Nevskia soli,,core
+1122605,Niabella aurantiaca DSM17617,Niabella aurantiaca,,periphery
+1122609,Nocardioides halotolerans DSM19273,Nocardioides halotolerans,,periphery
+1122611,Nonomuraea coxensis DSM45129,Nonomuraea coxensis,,periphery
+1122612,Novosphingobium acidiphilum DSM19966,Novosphingobium acidiphilum,,periphery
+1122613,Oceanicaulis alexandrii DSM11625,Oceanicaulis alexandrii,,periphery
+1122614,Oceanicola nanhaiensis DSM18065,Oceanicola nanhaiensis,,periphery
+1122619,Oligella ureolytica DSM18253,Oligella ureolytica,,periphery
+1122621,Olivibacter sitiensis DSM17696,Olivibacter sitiensis,,core
+1122622,Ornithinimicrobium pekingense DSM21552,Ornithinimicrobium pekingense,,periphery
+1122915,Paenibacillus alginolyticus DSM5050,Paenibacillus alginolyticus,,periphery
+1122917,Paenibacillus daejeonensis DSM15491,Paenibacillus daejeonensis,,periphery
+1122918,Paenibacillus fonticola DSM21315,Paenibacillus fonticola,,periphery
+1122919,Paenibacillus ginsengihumi DSM21568,Paenibacillus ginsengihumi,,periphery
+1122921,Paenibacillus massiliensis 2301065,Paenibacillus massiliensis,,periphery
+1122925,Paenibacillus sanguinis 2301083,Paenibacillus sanguinis,,periphery
+1122927,Paenibacillus terrigena DSM21567,Paenibacillus terrigena,,periphery
+1122929,Pannonibacter phragmitetus DSM14782,Pannonibacter phragmitetus,,core
+1122931,Parabacteroides gordonii DSM23371,Parabacteroides gordonii,,core
+1122933,Paraoerskovia marina DSM21750,Paraoerskovia marina,,periphery
+1122939,Patulibacter americanus DSM16676,Patulibacter americanus,,periphery
+1122947,Pelosinus fermentans DSM17108,Pelosinus fermentans,,periphery
+1122951,Perlucidibaca piscinae DSM21586,Perlucidibaca piscinae,,core
+1122962,Pleomorphomonas koreensis DSM23070,Pleomorphomonas koreensis,,core
+1122963,Pleomorphomonas oryzae DSM16300,Pleomorphomonas oryzae,,periphery
+1122970,Porphyrobacter cryptus DSM12079,Porphyrobacter cryptus,,periphery
+1122971,Porphyromonas bennonis DSM23058,Porphyromonas bennonis,,periphery
+1122973,Porphyromonas levii DSM23370,Porphyromonas levii,,periphery
+1122975,Porphyromonas somerae DSM23386,Porphyromonas somerae,,periphery
+1122978,Prevotella albensis DSM11370,Prevotella albensis,,periphery
+1122981,Prevotella corporis DSM18810,Prevotella corporis,,periphery
+1122983,Prevotella falsenii DSM22864,Prevotella falsenii,,periphery
+1122985,Prevotella loescheii DSM19665,Prevotella loescheii,,periphery
+1122986,Prevotella maculosa DSM19339,Prevotella maculosa,,periphery
+1122989,Prevotella oris DSM18711,Prevotella oris DSM18711,,periphery
+1122990,Prevotella paludivivens DSM17968,Prevotella paludivivens,,periphery
+1122991,Prevotella shahii DSM15611,Prevotella shahii,,periphery
+1122992,Prevotella timonensis 4401737,Prevotella timonensis 4401737,,periphery
+1122993,Prevotella veroralis DSM19559,Prevotella veroralis DSM19559,,periphery
+1122994,Propionibacterium acidifaciens DSM21887,Propionibacterium acidifaciens,,periphery
+1122997,Propionibacterium jensenii DSM20535,Propionibacterium jensenii,,periphery
+1122998,Propionibacterium thoenii DSM20276,Propionibacterium thoenii,,periphery
+1123008,Proteiniphilum acetatigenes DSM18083,Proteiniphilum acetatigenes,,core
+1123009,Proteocatella sphenisci DSM23131,Proteocatella sphenisci,,core
+1123013,Pseudoclavibacter soli DSM23366,Pseudoclavibacter soli,,periphery
+1123020,Pseudomonas resinovorans DSM21078,Pseudomonas resinovorans DSM21078,,periphery
+1123023,Pseudonocardia acaciae DSM45401,Pseudonocardia acaciae,,periphery
+1123024,Pseudonocardia asaccharolytica DSM44247,Pseudonocardia asaccharolytica,,periphery
+1123033,Psychrobacter lutiphocae DSM21542,Psychrobacter lutiphocae,,periphery
+1123034,Psychrobacter phenylpyruvicus DSM7000,Psychrobacter phenylpyruvicus,,periphery
+1123035,Psychroflexus tropicus DSM15496,Psychroflexus tropicus,,periphery
+1123037,Psychroserpens burtonensis DSM12212,Psychroserpens burtonensis,,periphery
+1123052,Rathayibacter toxicus DSM7488,Rathayibacter toxicus,,periphery
+1123053,Rheinheimera baltica DSM14885,Rheinheimera baltica,,periphery
+1123054,Rheinheimera perlucida DSM18276,Rheinheimera perlucida,,periphery
+1123057,Rhodonellum psychrophilum GCM71,Rhodonellum psychrophilum,,core
+1123058,Riemerella columbina DSM16469,Riemerella columbina,,periphery
+1123059,Robiginitomaculum antarcticum DSM21748,Robiginitomaculum antarcticum,,periphery
+1123060,Roseomonas aerilata DSM19363,Roseomonas aerilata,,periphery
+1123065,Ruania albidiflava DSM18029,Ruania albidiflava,,core
+1123070,Rubritalea marina DSM17716,Rubritalea marina,,periphery
+1123072,Rubritepida flocculans DSM14296,Rubritepida flocculans,,periphery
+1123073,Rudaea cellulosilytica DSM22992,Rudaea cellulosilytica,,periphery
+1123075,Ruminococcus gauvreauii DSM19829,Ruminococcus gauvreauii,,periphery
+1123226,Saccharibacillus kuerlensis DSM22868,Saccharibacillus kuerlensis,,core
+1123227,Saccharibacter floricola DSM15669,Saccharibacter floricola,,periphery
+1123228,Saccharospirillum impatiens DSM12546,Saccharospirillum impatiens,,core
+1123229,Salinarimonas rosea DSM21201,Salinarimonas rosea,,periphery
+1123230,Salinicoccus albus DSM19776,Salinicoccus albus,,periphery
+1123234,Salinimicrobium terrae DSM17865,Salinimicrobium terrae,,core
+1123236,Salinimonas chungwhensis DSM16280,Salinimonas chungwhensis,,core
+1123237,Salipiger mucosus DSM16094,Salipiger mucosus,,core
+1123239,Salsuginibacillus kocurii DSM18087,Salsuginibacillus kocurii,,core
+1123240,Sandarakinorhabdus limnophila DSM17366,Sandarakinorhabdus limnophila,,periphery
+1123242,Schlesneria paludicola DSM18645,Schlesneria paludicola,,core
+1123247,Sediminimonas qiaohouensis DSM21189,Sediminimonas qiaohouensis,,core
+1123248,Segetibacter koreensis DSM18137,Segetibacter koreensis,,core
+1123250,Selenomonas bovis DSM23594,Selenomonas bovis,,periphery
+1123251,Serinicoccus marinus DSM15273,Serinicoccus marinus,,periphery
+1123252,Shimazuella kribbensis DSM45090,Shimazuella kribbensis,,periphery
+1123253,Silanimonas lenta DSM16282,Silanimonas lenta,,periphery
+1123255,Simplicispira psychrophila DSM11588,Simplicispira psychrophila,,core
+1123256,Solimonas variicoloris DSM15731,Solimonas variicoloris,,core
+1123257,Solimonas flava DSM18980,Solimonas flava,,periphery
+1123258,Smaragdicoccus niigatensis DSM44881,Smaragdicoccus niigatensis,,periphery
+1123261,Solimonas soli DSM21787,Solimonas soli,,periphery
+1123263,Solobacterium moorei DSM22971,Solobacterium moorei DSM22971,,periphery
+1123267,Sphingomonas astaxanthinifaciens DSM22298,Sphingomonas astaxanthinifaciens,,periphery
+1123269,Sphingomonas sanxanigenens DSM19645,Sphingomonas sanxanigenens,,periphery
+1123270,Sphingopyxis baekryungensis DSM16222,Sphingopyxis baekryungensis,,periphery
+1123274,Spirochaeta bajacaliforniensis DSM16054,Spirochaeta bajacaliforniensis,,periphery
+1123276,Spirosoma luteum DSM19990,Spirosoma luteum,,periphery
+1123277,Spirosoma panaciterrae DSM21099,Spirosoma panaciterrae,,periphery
+1123278,Spirosoma spitsbergense DSM19989,Spirosoma spitsbergense,,core
+1123279,Spongiibacter tropicus DSM19543,Spongiibacter tropicus,,core
+1123284,Sporolactobacillus vineae DSM21990,Sporolactobacillus vineae,,periphery
+1123288,Sporomusa ovata DSM2662,Sporomusa ovata,,core
+1123290,Sporosarcina ureae DSM2281,Sporosarcina ureae,,periphery
+1123296,Stenoxybacter acetivorans DSM19021,Stenoxybacter acetivorans,,core
+1123298,Streptococcus caballi DSM19004,Streptococcus caballi,,periphery
+1123299,Streptococcus castoreus DSM17536,Streptococcus castoreus,,periphery
+1123300,Streptococcus devriesei DSM19639,Streptococcus devriesei,,periphery
+1123301,Streptococcus didelphis DSM15616,Streptococcus didelphis,,periphery
+1123302,Streptococcus entericus DSM14446,Streptococcus entericus,,periphery
+1123303,Streptococcus ferus DSM20646,Streptococcus ferus,,periphery
+1123304,Streptococcus henryi DSM19005,Streptococcus henryi,,periphery
+1123306,Streptococcus marimammalium DSM18627,Streptococcus marimammalium,,periphery
+1123307,Streptococcus massiliensis DSM18628,Streptococcus massiliensis,,periphery
+1123308,Streptococcus merionis DSM19192,Streptococcus merionis,,periphery
+1123309,Streptococcus minor DSM17118,Streptococcus minor,,periphery
+1123311,Streptococcus orisratti DSM15617,Streptococcus orisratti,,periphery
+1123312,Streptococcus ovis DSM16829,Streptococcus ovis,,periphery
+1123313,Faecalicoccus pleomorphus DSM20574,Faecalicoccus pleomorphus,,core
+1123314,Streptococcus plurextorum DSM22810,Streptococcus plurextorum,,periphery
+1123315,Streptococcus porci DSM23759,Streptococcus porci,,periphery
+1123318,Streptococcus thoraltensis DSM12221,Streptococcus thoraltensis,,periphery
+1123319,Streptomyces flavidovirens DSM40150,Streptomyces flavidovirens,,periphery
+1123320,Streptomyces scabrisporus DSM41855,Streptomyces scabrisporus,,periphery
+1123321,Streptomyces sulphureus DSM40104,Streptomyces sulphureus,,periphery
+1123322,Streptomyces vitaminophilus DSM41686,Streptomyces vitaminophilus,,periphery
+1123325,Sulfurihydrogenibium subterraneum DSM15120,Sulfurihydrogenibium subterraneum,,periphery
+1123326,Sulfurospirillum arcachonense DSM9755,Sulfurospirillum arcachonense,,periphery
+1123354,Tepidiphilus margaritifer DSM15129,Tepidiphilus margaritifer,,core
+1123355,Terasakiella pusilla DSM6293,Terasakiella pusilla,,core
+1123359,Tetragenococcus muriaticus DSM15685,Tetragenococcus muriaticus,,periphery
+1123360,Thalassobacter arenae DSM19593,Thalassobacter arenae,,periphery
+1123366,Thalassospira xiamenensis M-5,Thalassospira xiamenensis,,periphery
+1123367,Thauera linaloolentis 47Lol,Thauera linaloolentis,,periphery
+1123368,Thermithiobacillus tepidarius DSM3134,Thermithiobacillus tepidarius,,periphery
+1123371,Thermodesulfatator atlanticus DSM21156,Thermodesulfatator atlanticus,,periphery
+1123372,Thermodesulfobacterium hveragerdense DSM12571,Thermodesulfobacterium hveragerdense,,periphery
+1123373,Thermodesulfobacterium thermophilum DSM1276,Thermodesulfobacterium thermophilum,,periphery
+1123376,Thermodesulfovibrio thiophilus DSM17215,Thermodesulfovibrio thiophilus,,periphery
+1123377,Thermomonas fusca DSM15424,Thermomonas fusca,,periphery
+1123386,Thermus antranikianii DSM12462,Thermus antranikianii,,periphery
+1123388,Thermus igniterrae ATCC700962,Thermus igniterrae,,periphery
+1123389,Thermus islandicus DSM21543,Thermus islandicus,,periphery
+1123392,Thiobacillus denitrificans DSM12475,Thiobacillus denitrificans DSM12475,,periphery
+1123393,Thiobacillus thioparus DSM505,Thiobacillus thioparus,,periphery
+1123399,Thiothrix disciformis DSM14473,Thiothrix disciformis,,periphery
+1123400,Thiothrix flexilis DSM14609,Thiothrix flexilis,,periphery
+1123401,Thiothrix lacustris DSM21227,Thiothrix lacustris,,periphery
+1123405,Tuberibacillus calidus DSM17572,Tuberibacillus calidus,,core
+1123487,Uliginosibacterium gangwonense DSM18521,Uliginosibacterium gangwonense,,core
+1123488,Varibaculum cambriense DSM15806,Varibaculum cambriense DSM15806,,periphery
+1123489,Veillonella magna DSM19857,Veillonella magna,,periphery
+1123499,Vitreoscilla stercoraria DSM513,Vitreoscilla stercoraria,,core
+1123500,Weissella halotolerans DSM20190,Weissella halotolerans,,periphery
+1123501,Wenxinia marina DSM24838,Wenxinia marina,,core
+1123502,Wohlfahrtiimonas chitiniclastica DSM18708,Wohlfahrtiimonas chitiniclastica,,periphery
+1123503,Woodsholea maritima DSM17123,Woodsholea maritima,,core
+1123504,Xenophilus azovorans DSM13620,Xenophilus azovorans,,core
+1123507,Yaniella halotolerans DSM15476,Yaniella halotolerans,,periphery
+1123508,Zavarzinella formosa DSM19928,Zavarzinella formosa,,core
+1123511,Zymophilus raffinosivorans DSM20765,Zymophilus raffinosivorans,,core
+1123514,Thiomicrospira arctica DSM13458,Thiomicrospira arctica,,periphery
+1123517,Thiomicrospira pelophila DSM1534,Thiomicrospira pelophila,,periphery
+1123518,Thiomicrospira sp. Kp2,Thiomicrospira sp. Kp2,,periphery
+1123519,Pseudomonas stutzeri DSM10701,Pseudomonas stutzeri DSM10701,,periphery
+1124780,Nafulsella turpanensis ZLM-10,Nafulsella turpanensis,,core
+1124982,Treponema sp. JC4,Treponema sp. JC4,,core
+1124983,Pseudomonas protegens CHA0,Pseudomonas protegens CHA0,,periphery
+1124991,Morganella morganii subsp. morganii KT,Morganella morganii,,core
+1125699,Treponema maltophilum ATCC51939,Treponema maltophilum,,periphery
+1125700,Treponema medium ATCC700293,Treponema medium,,periphery
+1125701,Treponema socranskii subsp. paredis ATCC35535,Treponema socranskii paredis,,periphery
+1125712,Olsenella profusa F0195,Olsenella profusa,,periphery
+1125718,Actinomyces massiliensis F0489,Actinomyces massiliensis,,periphery
+1125725,Treponema socranskii subsp. socranskii VPI DR56BR1116,Treponema socranskii VPIDR56BR1116,,periphery
+1125779,Corynebacterium pyruviciproducens ATCC BAA-1742,Corynebacterium pyruviciproducens,,periphery
+1125863,Deferrisoma camini S3R1,Deferrisoma camini,,core
+1125971,Amycolatopsis orientalis DSM40040,Amycolatopsis orientalis,,periphery
+1125973,Bosea sp. 117,Bosea sp. 117,,periphery
+1126627,Bradyrhizobium sp. DOA9,Bradyrhizobium sp. DOA9,,periphery
+1127131,Weissella confusa LBAE C39-2,Weissella confusa,,periphery
+1127134,Nocardia cyriacigeorgica GUH-2,Nocardia cyriacigeorgica,,core
+1127673,Glaciecola lipolytica E3,Glaciecola lipolytica,,periphery
+1127692,Capnocytophaga sp. oral taxon 332 str. F0381,Capnocytophaga sp. F0381,,periphery
+1127695,Selenomonas sp. oral taxon 138 str. F0429,Selenomonas sp. F0429,,periphery
+1127696,Porphyromonas catoniae F0037,Porphyromonas catoniae,,periphery
+1128111,Veillonella atypica KON,Veillonella atypica KON,,periphery
+1128398,[Clostridium] acidurici 9a,Clostridium acidurici,,periphery
+1128421,Bacterium sp. JKG1,Bacterium sp. JKG1,,periphery
+1128427,filamentous cyanobacterium ESFC-1,filamentous cyanobacterium,,periphery
+1128912,Glaciecola mesophila KMM 241,Glaciecola mesophila,,core
+1129368,Spiroplasma melliferum IPMB4A,Spiroplasma melliferum,,periphery
+1129369,Mycoplasma hyorhinis GDL-1,Mycoplasma hyorhinis GDL1,,core
+1129374,Alishewanella jeotgali KCTC 22429,Alishewanella jeotgali,,periphery
+1129794,Glaciecola psychrophila 170,Glaciecola psychrophila,,periphery
+1131266,Marine Group I thaumarchaeote SCGC AB-629-I23,Thaumarchaeota sp. SCGC AB629I23,,core
+1131269,Nitrospina sp. AB-629-B18,Nitrospina sp. AB629B18,,core
+1131451,Xanthomonas fragariae LMG 25863,Xanthomonas fragariae,,periphery
+1131462,Dehalobacter sp. CF,Dehalobacter sp. CF,,core
+1131553,Nitrosomonas cryotolerans ATCC49181,Nitrosomonas cryotolerans,,periphery
+1131730,Bacillus vireti LMG 21834,Bacillus vireti,,periphery
+1131812,Flavobacterium sp. 83,Flavobacterium sp. 83,,periphery
+1131813,Methylobacterium sp. 88A,Methylobacterium sp. 88A,,periphery
+1131814,Xanthobacter sp. 126,Xanthobacter sp. 126,,periphery
+1132441,Arthrobacter sp. 35W,Arthrobacter sp. 35W,,periphery
+1132442,Bacillus sp. 37MA,Bacillus sp. 37MA,,periphery
+1132509,Halococcus hamelinensis 100A6,Halococcus hamelinensis,,periphery
+1132836,Rhizobium sp. CCGE 510,Rhizobium sp. CCGE510,,periphery
+1132855,Methylotenera mobilis 13,Methylotenera mobilis 13,,periphery
+1133569,Lactobacillus vini DSM20605,Lactobacillus vini,,periphery
+1133849,Nocardia brasiliensis ATCC700358,Nocardia brasiliensis,,periphery
+1133850,Streptomyces hygroscopicus subsp. jinggangensis 5008,Streptomyces hygroscopicus,,periphery
+1134413,Bacillus sp. L1(2012),Bacillus sp. L1,,periphery
+1134445,Streptomyces somaliensis DSM40738,Streptomyces somaliensis,,periphery
+1134474,Cellvibrio sp. BR,Cellvibrio sp. BR,,periphery
+1134510,Bartonella koehlerae C-29,Bartonella koehlerae,,periphery
+1134912,Methylocystis parvus OBBP,Methylocystis parvus,,periphery
+1136138,Pseudomonas fragi B25,Pseudomonas fragi,,periphery
+1136163,Vibrio cyclitrophicus FF75,Vibrio cyclitrophicus,,periphery
+1136177,Lactobacillus pentosus KCA1,Lactobacillus pentosus,,periphery
+1136417,Salinispora pacifica CNT003,Salinispora pacifica,,periphery
+1137268,Nocardiopsis sp. CNT312,Nocardiopsis sp. CNT312,,periphery
+1137269,Streptomyces sp. CNH099,Streptomyces sp. CNH099,,periphery
+1137271,Saccharomonospora sp. CNQ490,Saccharomonospora sp. CNQ490,,periphery
+1137281,Formosa sp. AK20,Formosa sp. AK20,,core
+1137799,Endozoicomonas numazuensis,Endozoicomonas numazuensis,,core
+1138822,Lactobacillus curieae,Lactobacillus curieae,,periphery
+1139219,Enterococcus dispar ATCC51266,Enterococcus dispar,,periphery
+1139996,Enterococcus saccharolyticus ATCC43076,Enterococcus saccharolyticus,,periphery
+1140001,Enterococcus durans ATCC6056,Enterococcus durans,,periphery
+1140002,Enterococcus avium ATCC14025,Enterococcus avium,,periphery
+1140003,Enterococcus sulfureus ATCC49903,Enterococcus sulfureus,,periphery
+1141106,Staphylococcus intermedius NCTC 11048,Staphylococcus intermedius,,periphery
+1141662,Providencia burhodogranariea DSM19968,Providencia burhodogranariea,,periphery
+1141663,Providencia rettgeri Dmel1,Providencia rettgeri Dmel1,,periphery
+1142394,Phycisphaera mikurensis NBRC 102666,Phycisphaera mikurensis,,core
+1142511,Wigglesworthia glossinidia endosymbiont of Glossina morsitans morsitans (Yale colony),Wigglesworthia glossinidia sp. Gmo,,periphery
+1143323,Chlamydia gallinacea 08-1274/3,Chlamydia gallinacea,,periphery
+1144275,Corallococcus coralloides DSM2259,Corallococcus coralloides,,periphery
+1144305,Novosphingobium sp. AP12,Novosphingobium sp. AP12,,periphery
+1144307,Sphingobium sp. AP49,Sphingobium sp. AP49,,periphery
+1144310,Rhizobium sp. CF080,Rhizobium sp. CF080,,periphery
+1144312,Rhizobium sp. CF122,Rhizobium sp. CF122,,periphery
+1144313,Flavobacterium sp. CF136,Flavobacterium sp. CF136,,periphery
+1144319,Herbaspirillum sp. CF444,Herbaspirillum sp. CF444,,periphery
+1144325,Pseudomonas sp. GM21,Pseudomonas sp. GM21,,periphery
+1144342,Herbaspirillum sp. YR522,Herbaspirillum sp. YR522,,periphery
+1144343,Phyllobacterium sp. YR531,Phyllobacterium sp. YR531,,periphery
+1144664,Acinetobacter sp. CIP 102129,Acinetobacter sp. CIP102129,,periphery
+1144672,Acinetobacter sp. CIP 56.2,Acinetobacter sp. CIP56.2,,core
+1144888,Rickettsia helvetica C9P9,Rickettsia helvetica,,periphery
+1144932,Candidatus Pelagibacter ubique HIMB058,Pelagibacter ubique HIMB058,,periphery
+1145276,Lysinibacillus varians,Lysinibacillus varians,,core
+1146883,Blastococcus saxobsidens DD2,Blastococcus saxobsidens,,periphery
+1147128,Bifidobacterium asteroides PRL2011,Bifidobacterium asteroides,,periphery
+1149133,Pseudomonas pseudoalcaligenes KF707,Pseudomonas pseudoalcaligenes KF707,,periphery
+1150398,Arthrobacter sp. 9MFCol3.1,Arthrobacter sp. 9MFCol31,,periphery
+1150399,Leifsonia sp. 109,Leifsonia sp. 109,,periphery
+1150469,Rhodospirillum photometricum DSM122,Rhodospirillum photometricum,,periphery
+1150474,Mesoaciditoga lauensis cd-1655R,Mesoaciditoga lauensis,,core
+1150599,Mycobacterium phlei RIVM601174,Mycobacterium phlei,,periphery
+1150600,Arcticibacter svalbardensis MN12-7,Arcticibacter svalbardensis,,core
+1150621,Sulfurospirillum multivorans DSM12446,Sulfurospirillum multivorans,,periphery
+1150626,Phaeospirillum molischianum DSM120,Phaeospirillum molischianum,,periphery
+1150864,Micromonospora lupini str. Lupac 08,Micromonospora lupini,,periphery
+1151061,Tsukamurella sp. 1534,Tsukamurella sp. 1534,,periphery
+1151116,Rahnella aquatilis HX2,Rahnella aquatilis HX2,,periphery
+1151117,Thermococcus zilligii AN1,Thermococcus zilligii,,periphery
+1151118,Arthrobacter sp. 161MFSha2.1,Arthrobacter sp. 161MFSha21,,periphery
+1151119,Arthrobacter sp. 162MFSha1.1,Arthrobacter sp. 162MFSha11,,periphery
+1151122,Microbacterium sp. 292MF,Microbacterium sp. 292MF,,periphery
+1151126,Microbacterium paraoxydans 77MFTsu3.2,Microbacterium paraoxydans 77MFTsu32,,periphery
+1151127,Pseudomonas mandelii 36MFCvi1.1,Pseudomonas mandelii 36MFCvi11,,periphery
+1151292,Peptoclostridium difficile CD160,Peptoclostridium difficile CD160,,periphery
+1154757,Leuconostoc pseudomesenteroides 4882,Leuconostoc pseudomesenteroides,,periphery
+1154860,Streptococcus agalactiae LMG 14747,Streptococcus agalactiae LMG14747,,periphery
+1155714,Streptomyces sp. LaPpAH-108,Streptomyces sp. LaPpAH108,,periphery
+1155718,Streptomyces sp. MspMP-M5,Streptomyces sp. MspMPM5,,periphery
+1156844,Streptomyces sp. HmicA12,Streptomyces sp. HmicA12,,periphery
+1156919,Achromobacter piechaudii HLE,Achromobacter piechaudii HLE,,periphery
+1156935,Agrobacterium albertimagni AOL15,Agrobacterium albertimagni,,periphery
+1156937,Methylacidiphilum fumariolicum SolV,Methylacidiphilum fumariolicum,,periphery
+1157490,Tumebacillus flagellatus,Tumebacillus flagellatus,,core
+1157632,Streptomyces sp. LaPpAH-95,Streptomyces sp. LaPpAH95,,periphery
+1157634,Streptomyces sp. Amel2xE9,Streptomyces sp. Amel2xE9,,periphery
+1157635,Streptomyces sp. ATexAB-D23,Streptomyces sp. ATexABD23,,periphery
+1157637,Streptomyces sp. BoleA5,Streptomyces sp. BoleA5,,periphery
+1157638,Streptomyces sp. PsTaAH-124,Streptomyces sp. PsTaAH124,,periphery
+1157640,Streptomyces sp. FxanaC1,Streptomyces sp. FxanaC1,,periphery
+1157708,Variovorax paradoxus 110B,Variovorax paradoxus 110B,,periphery
+1157943,Mycobacterium sp. 155,Mycobacterium sp. 155,,periphery
+1158050,Arthrobacter sp. 135MFCol5.1,Arthrobacter sp. 135MFCol51,,periphery
+1158146,Thioalkalivibrio sp. ALJT,Thioalkalivibrio sp. ALJT,,periphery
+1158150,Thioalkalivibrio sp. ALD1,Thioalkalivibrio sp. ALD1,,periphery
+1158165,Thioalkalivibrio sp. ALMg11,Thioalkalivibrio sp. ALMg11,,periphery
+1158182,Thioalkalivibrio sp. ALE31,Thioalkalivibrio sp. ALE31,,periphery
+1158292,Thiomonas sp. FB-Cd,Thiomonas sp. FBCd,,periphery
+1158294,Prevotella sp. 10(H),Prevotella sp. 10,,periphery
+1158318,Desulfurobacterium sp. TC5-1,Desulfurobacterium sp. TC51,,periphery
+1158338,Persephonella sp. IF05-L8,Persephonella sp. IF05L8,,periphery
+1158345,Persephonella sp. KM09-Lau-8,Persephonella sp. KM09Lau8,,periphery
+1158601,Enterococcus malodoratus ATCC43197,Enterococcus malodoratus,,periphery
+1158602,Enterococcus raffinosus ATCC49464,Enterococcus raffinosus,,periphery
+1158604,Enterococcus villorum ATCC700913,Enterococcus villorum,,periphery
+1158606,Enterococcus asini ATCC700915,Enterococcus asini,,periphery
+1158607,Enterococcus pallens ATCC BAA-351,Enterococcus pallens,,periphery
+1158608,Enterococcus haemoperoxidus ATCC BAA-382,Enterococcus haemoperoxidus,,periphery
+1158609,Enterococcus moraviensis ATCC BAA-383,Enterococcus moraviensis,,periphery
+1158610,Enterococcus phoeniculicola ATCC BAA-412,Enterococcus phoeniculicola,,periphery
+1158612,Enterococcus caccae ATCC BAA-1240,Enterococcus caccae,,periphery
+1158614,Enterococcus gilvus ATCC BAA-350,Enterococcus gilvus,,periphery
+1158756,Thioalkalivibrio sp. ALJ7,Thioalkalivibrio sp. ALJ7,,periphery
+1158760,Thioalkalivibrio sp. ALJ11,Thioalkalivibrio sp. ALJ11,,periphery
+1158762,Thioalkalivibrio sp. ALJ16,Thioalkalivibrio sp. ALJ16,,periphery
+1159488,Staphylococcus equorum subsp. equorum Mu2,Staphylococcus equorum,,periphery
+1159870,Bordetella sp. FB-8,Bordetella sp. FB8,,periphery
+1160137,Nocardia sp. BMG111209,Nocardia sp. BMG111209,,periphery
+1160707,Ureibacillus thermosphaericus str. Thermo-BF,Ureibacillus thermosphaericus,,core
+1160718,Streptomyces auratus AGR0001,Streptomyces auratus,,periphery
+1160721,Ruminococcus bicirculans,Ruminococcus bicirculans,,periphery
+1161401,Maricaulis sp. JL2009,Maricaulis sp. JL2009,,periphery
+1161413,Streptococcus sp. ACC21,Streptococcus sp. ACC21,,periphery
+1161902,Eubacterium nodatum ATCC33099,Eubacterium nodatum,,periphery
+1162668,Leptospirillum ferrooxidans C2-3,Leptospirillum ferrooxidans,,core
+1163385,Peanut witches'-broom phytoplasma NTU2011,Phytoplasma peanut witchesbroom,,periphery
+1163389,Francisella noatunensis subsp. orientalis str. Toba 04,Francisella noatunensis,,periphery
+1163398,Pseudomonas sp. HYS,Pseudomonas sp. HYS,,periphery
+1163407,Rhodanobacter spathiphylli B39,Rhodanobacter spathiphylli,,periphery
+1163408,Rhodanobacter fulvus Jip2,Rhodanobacter fulvus,,periphery
+1163409,Rhodanobacter thiooxydans LCS2,Rhodanobacter thiooxydans,,periphery
+1163617,Sulfuricella denitrificans skB26,Sulfuricella denitrificans,,core
+1163671,Clostridium sp. 12(A),Clostridium sp. 12,,periphery
+1163730,Fervidicoccus fontis Kam940,Fervidicoccus fontis,,core
+1163745,Helicobacter cetorum MIT 99-5656,Helicobacter cetorum MIT995656,,periphery
+1165094,Richelia intracellularis HH01,Richelia intracellularis,,periphery
+1165096,Methylotenera sp. 73s,Methylotenera sp. 73s,,periphery
+1165841,Sulfurovum sp. AR,Sulfurovum sp. AR,,periphery
+1166016,Pectobacterium sp. SCC3193,Pectobacterium sp. SCC3193,,periphery
+1166018,Fibrella aestuarina BUZ 2,Fibrella aestuarina,,core
+1166130,Enterobacter sp. R4-368,Enterobacter sp. R4368,,periphery
+1166948,Halomonas xinjiangensis,Halomonas xinjiangensis,,periphery
+1167006,Desulfocapsa sulfexigens DSM10523,Desulfocapsa sulfexigens,,periphery
+1167632,Staphylococcus vitulinus F1028,Staphylococcus vitulinus,,periphery
+1168034,Draconibacterium orientale,Draconibacterium orientale,,periphery
+1168059,Xanthobacteraceae bacterium 501b,Xanthobacteraceae bacterium 501b,,periphery
+1168065,gamma proteobacterium BDW918,Gammaproteobacteria bacterium BDW918,,core
+1168067,Thiomicrospira kuenenii DSM12350,Thiomicrospira kuenenii,,periphery
+1168289,Marinilabilia salmonicolor JCM 21150,Marinilabilia salmonicolor,,periphery
+1169143,Burkholderia bryophila 376MFSha3.1,Burkholderia bryophila,,periphery
+1169144,Bacillus sp. 123MFChir2,Bacillus sp. 123MFChir2,,periphery
+1169152,Nocardia sp. CNY236,Nocardia sp. CNY236,,periphery
+1169154,Streptomyces sp. CNT372,Streptomyces sp. CNT372,,periphery
+1169161,Streptomyces sp. CNY243,Streptomyces sp. CNY243,,periphery
+1170318,Propionibacterium avidum 44067,Propionibacterium avidum,,periphery
+1170562,Calothrix sp. PCC6303,Calothrix sp. PCC6303,,periphery
+1171373,Propionibacterium acidipropionici ATCC4875,Propionibacterium acidipropionici,,periphery
+1172179,Streptomyces sp. 142MFCol3.1,Streptomyces sp. 142MFCol31,,periphery
+1172180,Streptomyces sp. 351MFTsu5.1,Streptomyces sp. 351MFTsu51,,periphery
+1172181,Streptomyces sp. 303MFCol5.2,Streptomyces sp. 303MFCol52,,periphery
+1172185,Nocardia sp. 348MFTsu5.1,Nocardia sp. 348MFTsu51,,periphery
+1172186,Mycobacterium sp. 360MFTsu5.1,Mycobacterium sp. 360MFTsu51,,periphery
+1172188,Terracoccus sp. 273MFTsu3.1,Terracoccus sp. 273MFTsu31,,core
+1172190,Sulfurimonas sp. AST-10,Sulfurimonas sp. AST10,,periphery
+1172562,Helicobacter cinaedi PAGU611,Helicobacter cinaedi PAGU611,,periphery
+1173020,Chamaesiphon minutus PCC6605,Chamaesiphon minutus,,core
+1173021,Cyanobacterium sp. PCC7702,Cyanobacterium sp. PCC7702,,core
+1173022,Crinalium epipsammum PCC9333,Crinalium epipsammum,,core
+1173023,Fischerella sp. PCC9431,Fischerella sp. PCC9431,,core
+1173024,Fischerella sp. PCC9605,Fischerella sp. PCC9605,,periphery
+1173025,Geitlerinema sp. PCC7407,Geitlerinema sp. PCC7407,,core
+1173026,Gloeocapsa sp. PCC7428,Gloeocapsa sp. PCC7428,,core
+1173027,Microcoleus sp. PCC7113,Microcoleus sp. PCC7113,,periphery
+1173028,Oscillatoria sp. PCC10802,Oscillatoria sp. PCC10802,,periphery
+1173029,Spirulina subsalsa PCC9445,Spirulina subsalsa,,core
+1173263,Synechococcus sp. PCC7502,Synechococcus sp. PCC7502,,periphery
+1173264,Leptolyngbya sp. PCC6406,Leptolyngbya sp. PCC6406,,periphery
+1173701,Colletotrichum sublineola,Colletotrichum sublineola,,periphery
+1174504,Bacillus psychrosaccharolyticus ATCC23296,Bacillus psychrosaccharolyticus,,periphery
+1174528,Fischerella sp. PCC9339,Fischerella sp. PCC9339,,periphery
+1174529,Candidatus Liberibacter asiaticus str. gxpsy,Liberibacter asiaticus gxpsy,,periphery
+1174684,Sphingopyxis sp. MC1,Sphingopyxis sp. MC1,,periphery
+1175306,Herbaspirillum sp. GW103,Herbaspirillum sp. GW103,,periphery
+1175629,Aerococcus viridans LL1,Aerococcus viridans LL1,,periphery
+1176165,Brevibacterium massiliense 5401308,Brevibacterium massiliense,,periphery
+1177154,Alcanivorax sp. 19-m-6,Alcanivorax sp. 19m6,,periphery
+1177179,Alcanivorax hongdengensis A-11-3,Alcanivorax hongdengensis,,periphery
+1177181,Alcanivorax jadensis T9,Alcanivorax jadensis,,periphery
+1177594,Microbacterium sp. C448,Microbacterium sp. C448,,periphery
+1177928,Thalassospira profundimaris WP0211,Thalassospira profundimaris,,periphery
+1178482,Halomonas sp. BJGMM-B45,Halomonas sp. BJGMMB45,,periphery
+1178537,Bacillus xiamenensis,Bacillus xiamenensis,,periphery
+1178540,Bacillus sp. DW5-4,Bacillus sp. DW54,,periphery
+1178825,Arenitalea lutea,Arenitalea lutea,,core
+1179155,Candidatus Photodesmus blepharus,Photodesmus blepharus,,periphery
+1179226,Staphylococcus lentus F1142,Staphylococcus lentus,,periphery
+1179773,Saccharothrix espanaensis DSM44229,Saccharothrix espanaensis,,periphery
+1179777,Mycoplasma sp. G5847,Mycoplasma sp. G5847,,periphery
+1179778,Pseudomonas sp. M47T1,Pseudomonas sp. M47T1,,periphery
+1182553,Cladophialophora psammophila,Cladophialophora psammophila,,periphery
+1182590,Pseudomonas pseudoalcaligenes CECT 5344,Pseudomonas pseudoalcaligenes CECT5344,,periphery
+1183377,Pyrococcus sp. ST04,Pyrococcus sp. ST04,,periphery
+1183438,Gloeobacter kilaueensis JS1,Gloeobacter kilaueensis,,periphery
+1184251,Thermogladius cellulolyticus 1633,Thermogladius cellulolyticus,,core
+1184267,Bdellovibrio exovorus JSS,Bdellovibrio exovorus,,periphery
+1184607,Austwickia chelonae NBRC 105200,Austwickia chelonae,,core
+1184609,Kineosphaera limosa NBRC 100340,Kineosphaera limosa,,periphery
+1185652,Sinorhizobium fredii USDA 257,Sinorhizobium fredii USDA257,,periphery
+1185653,Planococcus antarcticus DSM14505,Planococcus antarcticus,,periphery
+1185766,Thioclava dalianensis,Thioclava dalianensis,,periphery
+1185876,Fibrisoma limi BUZ 3,Fibrisoma limi,,core
+1186051,Blattabacterium sp. (Blaberus giganteus),Blattabacterium sp. Bgi,,core
+1187848,Vibrio genomosp. F10 str. ZF-129,Vibrio genomosp.,,periphery
+1187851,Rhodovulum sp. PH10,Rhodovulum sp. PH10,,periphery
+1188233,Mycoplasma auris 15026,Mycoplasma auris,,periphery
+1188234,Mycoplasma alkalescens 14918,Mycoplasma alkalescens,,periphery
+1188235,Mycoplasma bovigenitalium 51080,Mycoplasma bovigenitalium,,periphery
+1188236,Mycoplasma arginini 7264,Mycoplasma arginini,,periphery
+1188239,Mycoplasma ovipneumoniae 14811,Mycoplasma ovipneumoniae,,periphery
+1188240,Mycoplasma yeatsii 13926,Mycoplasma yeatsii,,periphery
+1188241,Ureaplasma diversum NCTC 246,Ureaplasma diversum,,periphery
+1188252,Vibrio rumoiensis 1S-45,Vibrio rumoiensis,,periphery
+1188256,Rhodovulum sulfidophilum DSM1374,Rhodovulum sulfidophilum,,periphery
+1189612,Indibacter alkaliphilus LW1,Indibacter alkaliphilus,,core
+1189619,Psychroflexus gondwanensis ACAM 44,Psychroflexus gondwanensis,,periphery
+1189620,Flavobacterium sp. ACAM 123,Flavobacterium sp. ACAM123,,periphery
+1190603,Enterovibrio norvegicus FF-33,Enterovibrio norvegicus,,periphery
+1190606,Enterovibrio calviensis 1F-211,Enterovibrio calviensis,,periphery
+1191299,Vibrio kanaloae 5S-149,Vibrio kanaloae,,periphery
+1191460,Acinetobacter venetianus RAG-1,Acinetobacter venetianus,,periphery
+1191523,Melioribacter roseus P3M-2,Melioribacter roseus,,periphery
+1192034,Chondromyces apiculatus DSM436,Chondromyces apiculatus,,periphery
+1192124,Burkholderia sp. lig30,Burkholderia sp. lig30,,periphery
+1192759,Sphingobium xenophagum QYY,Sphingobium xenophagum,,periphery
+1192868,Pseudaminobacter salicylatoxidans KCT001,Pseudaminobacter salicylatoxidans,,periphery
+1193128,Parascardovia denticolens IPLA20019,Parascardovia denticolens IPLA20019,,core
+1193181,Tetrasphaera elongata Lp2,Tetrasphaera elongata,,periphery
+1193729,Candidatus Endolissoclinum faulkneri L2,Endolissoclinum faulkneri L2,,core
+1194165,Microbacterium yannicii PS01,Microbacterium yannicii,,periphery
+1194526,Staphylococcus warneri SG1,Staphylococcus warneri SG1,,core
+1194972,Mycobacterium vaccae ATCC25954,Mycobacterium vaccae,,periphery
+1195236,[Clostridium] termitidis CT1112,Clostridium termitidis,,periphery
+1195246,Alishewanella agri BL06,Alishewanella agri,,core
+1196028,Virgibacillus halodenitrificans 1806,Virgibacillus halodenitrificans,,core
+1196029,Bacillus endophyticus 2102,Bacillus endophyticus,,periphery
+1196031,Bacillus oceanisediminis 2691,Bacillus oceanisediminis,,periphery
+1196083,Snodgrassella alvi,Snodgrassella alvi,,core
+1196095,Gilliamella apicola,Gilliamella apicola,,core
+1196322,Clostridium sp. Maddingley MBC34-26,Clostridium sp. Maddingley,,core
+1196323,Paenibacillus sp. OSY-SE,Paenibacillus sp. OSYSE,,periphery
+1196324,Bacillus macauensis ZFHKF-1,Bacillus macauensis,,periphery
+1196835,Pseudomonas stutzeri CCUG29243,Pseudomonas stutzeri CCUG 29243,,periphery
+1197130,Halococcus sp. 197A,Halococcus sp. 197A,,periphery
+1197477,Mangrovimonas yunxiaonensis,Mangrovimonas yunxiaonensis,,core
+1197706,Arthrobacter sp. M2012083,Arthrobacter sp. M2012083,,periphery
+1197719,Salmonella bongori N268-08,Salmonella bongori N26808,,periphery
+1197906,Afipia birgiae 34632,Afipia birgiae,,periphery
+1198114,Granulicella tundricola MP5ACTX9,Granulicella tundricola,,core
+1198232,Cycloclasticus zancles 7-ME,Cycloclasticus zancles,,core
+1198449,Aeropyrum camini SY1,Aeropyrum camini,,periphery
+1198452,Janthinobacterium sp. HH01,Janthinobacterium sp. HH01,,periphery
+1198676,Streptococcus mutans GS-5,Streptococcus mutans GS5,,periphery
+1200352,Corynebacterium terpenotabidum Y-11,Corynebacterium terpenotabidum,,periphery
+1200557,Anaerovibrio sp. RM50,Anaerovibrio sp. RM50,,periphery
+1200567,Ruminobacter sp. RM87,Ruminobacter sp. RM87,,core
+1200792,Brevibacillus brevis X23,Brevibacillus brevis X23,,periphery
+1201035,Bartonella birtlesii E11,Bartonella birtlesii,,periphery
+1201288,Bacteriovorax sp. Seq25_V,Bacteriovorax sp. Seq25V,,periphery
+1201290,Bacteriovorax sp. BAL6_X,Bacteriovorax sp. BAL6X,,core
+1201292,Enterococcus faecalis ATCC29212,Enterococcus faecalis ATCC29212,,core
+1201293,Moritella dasanensis ArB 0140,Moritella dasanensis,,periphery
+1202532,Flavobacterium sp. F52,Flavobacterium sp. F52,,periphery
+1202768,Halopiger salifodinae,Halopiger salifodinae,,periphery
+1202962,Moritella marina ATCC15381,Moritella marina,,core
+1203076,Lactobacillus ingluviei str. Autruche 4,Lactobacillus ingluviei,,periphery
+1203190,Corynebacterium timonense 5401744,Corynebacterium timonense,,periphery
+1203550,Prevotella oralis HGA0225,Prevotella oralis HGA0225,,periphery
+1203554,Sutterella wadsworthensis HGA0223,Sutterella wadsworthensis HGA0223,,periphery
+1203556,Actinomyces sp. HPA0247,Actinomyces sp. HPA0247,,periphery
+1203566,Corynebacterium sp. KPL1859,Corynebacterium sp. KPL1859,,periphery
+1203567,Corynebacterium sp. KPL1860,Corynebacterium sp. KPL1860,,periphery
+1203568,Dermabacter sp. HFH0086,Dermabacter sp. HFH0086,,periphery
+1203590,Streptococcus sp. HPH0090,Streptococcus sp. HPH0090,,periphery
+1203602,Atopobium sp. oral taxon 199 str. F0494,Atopobium sp. F0494,,periphery
+1203605,Propionibacterium sp. oral taxon 192 str. F0372,Propionibacterium sp. F0372,,periphery
+1203606,Butyricicoccus pullicaecorum 1.2,Butyricicoccus pullicaecorum,,core
+1203611,Alistipes onderdonkii WAL8169,Alistipes onderdonkii,,periphery
+1203622,Corynebacterium sp. KPL1989,Corynebacterium sp. KPL1989,,periphery
+1203632,Corynebacterium sp. KPL2004,Corynebacterium sp. KPL2004,,periphery
+1205680,Reyranella massiliensis 521,Reyranella massiliensis,,periphery
+1205681,Bartonella rattaustraliani AUST/NH4,Bartonella rattaustraliani,,periphery
+1205683,Yersinia massiliensis CCUG 53443,Yersinia massiliensis,,periphery
+1205753,Xanthomonas translucens DAR61454,Xanthomonas translucens,,periphery
+1205908,Vibrio breoganii 1C10,Vibrio breoganii,,periphery
+1205910,Nocardiopsis alba ATCC BAA-2165,Nocardiopsis alba,,periphery
+1206101,Streptomyces sp. CNR698,Streptomyces sp. CNR698,,periphery
+1206720,Nocardia aobensis NBRC 100429,Nocardia aobensis,,periphery
+1206725,Nocardia brevicatena NBRC 12119,Nocardia brevicatena,,periphery
+1206726,Nocardia carnea NBRC 14403,Nocardia carnea,,periphery
+1206729,Nocardia exalbida NBRC 100660,Nocardia exalbida,,periphery
+1206730,Nocardia higoensis NBRC 100133,Nocardia higoensis,,periphery
+1206731,Nocardia jiangxiensis NBRC 101359,Nocardia jiangxiensis,,periphery
+1206732,Nocardia otitidiscaviarum NBRC 14405,Nocardia otitidiscaviarum,,periphery
+1206733,Nocardia niigatensis NBRC 100131,Nocardia niigatensis,,periphery
+1206735,Nocardia takedensis NBRC 100417,Nocardia takedensis,,periphery
+1206737,Nocardia pneumoniae NBRC 100136,Nocardia pneumoniae,,periphery
+1206739,Nocardia testacea NBRC 100365,Nocardia testacea,,periphery
+1206741,Nocardia concava NBRC 100430,Nocardia concava,,periphery
+1206743,Nocardia veterana NBRC 100344,Nocardia veterana,,periphery
+1206744,Nocardia transvalensis NBRC 15921,Nocardia transvalensis,,periphery
+1206777,Pseudomonas sp. Lz4W,Pseudomonas sp. Lz4W,,core
+1207055,Sphingobium sp. C100,Sphingobium sp. C100,,periphery
+1207058,Hyphomonas sp. L-53-1-40,Hyphomonas sp. L53140,,periphery
+1207063,Oceanibaculum indicum P24,Oceanibaculum indicum,,core
+1207075,Pseudomonas sp. UW4,Pseudomonas sp. UW4,,periphery
+1207076,Pseudomonas luteola XLDN4-9,Pseudomonas luteola,,periphery
+1208321,Marinomonas sp. D104,Marinomonas sp. D104,,core
+1208323,Celeribacter baekdonensis B30,Celeribacter baekdonensis,,core
+1208583,Commensalibacter sp. MX01,Commensalibacter sp. MX01,,periphery
+1208918,Candidatus Kinetoplastibacterium crithidii TCC036E,Kinetoplastibacterium crithidii,,core
+1208919,Candidatus Kinetoplastibacterium desouzaii TCC079E,Kinetoplastibacterium desouzaii,,core
+1208920,Candidatus Kinetoplastibacterium oncopeltii TCC290E,Kinetoplastibacterium oncopeltii,,periphery
+1208921,Candidatus Kinetoplastibacterium galatii TCC219,Kinetoplastibacterium galatii,,periphery
+1208923,Candidatus Kinetoplastibacterium blastocrithidii (ex Strigomonas culicis),Kinetoplastibacterium blastocrithidii,,periphery
+1209072,Cellvibrio mixtus subsp. mixtus J3-8,Cellvibrio mixtus,,periphery
+1209984,Mycobacterium mageritense DSM44476,Mycobacterium mageritense,,periphery
+1209989,Tepidanaerobacter acetatoxydans Re1,Tepidanaerobacter acetatoxydans,,core
+1210045,Streptomyces sp. AA0539,Streptomyces sp. AA0539,,periphery
+1210046,Janibacter hoylei PVAS-1,Janibacter hoylei,,periphery
+1210884,Gemmata sp. IIL30,Gemmata sp. IIL30,,core
+1210908,Halogranum salarium B-1,Halogranum salarium,,periphery
+1211035,Lysinibacillus massiliensis 4400831,Lysinibacillus massiliensis,,periphery
+1211112,Pseudomonas psychrophila HA-4,Pseudomonas psychrophila,,periphery
+1211114,Pseudoxanthomonas sp. GW2,Pseudoxanthomonas sp. GW2,,periphery
+1211115,Chelatococcus sp. GW1,Chelatococcus sp. GW1,,core
+1211579,Pseudomonas putida NBRC 14164,Pseudomonas putida NBRC14164,,periphery
+1211777,Rhizobium mesoamericanum STM3625,Rhizobium mesoamericanum,,periphery
+1211813,Candidatus Alistipes marseilloanorexicus AP11,Alistipes marseilloanorexicus,,periphery
+1211814,Bacillus massilioanorexius AP8,Bacillus massilioanorexius,,periphery
+1211815,Candidatus Blastococcus massiliensis AP3,Blastococcus massiliensis,,periphery
+1211817,Candidatus Clostridium anorexicamassiliense AP5,Clostridium anorexicamassiliense,,periphery
+1211819,Holdemania massiliensis AP2,Holdemania massiliensis,,periphery
+1211844,Candidatus Stoquefichus massiliensis AP9,Stoquefichus massiliensis,,core
+1212548,Pseudomonas stutzeri NF13,Pseudomonas stutzeri NF13,,periphery
+1214065,Enterobacteriaceae bacterium B14,Enterobacteriaceae bacterium B14,,periphery
+1214101,Streptomyces davawensis JCM4913,Streptomyces davawensis,,periphery
+1214166,Streptococcus suis 86-5192,Streptococcus suis 865192,,periphery
+1214184,Streptococcus suis 22083,Streptococcus suis 22083,,periphery
+1214217,Streptococcus suis YS72,Streptococcus suis YS72,,periphery
+1214242,Streptomyces collinus Tu 365,Streptomyces collinus,,periphery
+1215092,Pseudomonas alcaligenes NBRC 14159,Pseudomonas alcaligenes NBRC14159,,periphery
+1215114,Pseudomonas parafulva NBRC 16636,Pseudomonas parafulva,,periphery
+1215343,Liberibacter crescens BT-1,Liberibacter crescens,,periphery
+1215915,Lactococcus raffinolactis 4877,Lactococcus raffinolactis,,periphery
+1216007,Pseudoalteromonas ruthenica CP76,Pseudoalteromonas ruthenica,,core
+1216362,Fusobacterium hwasookii ChDC F128,Fusobacterium hwasookii,,periphery
+1216932,Clostridium sp. M2/40,Clostridium sp. M240,,periphery
+1216966,Edwardsiella hoshinae NBRC105699,Edwardsiella hoshinae,,periphery
+1216967,Elizabethkingia meningoseptica ATCC13253,Elizabethkingia meningoseptica,,periphery
+1216976,Achromobacter xylosoxidans NBRC 15126,Achromobacter xylosoxidans NBRC15126,,periphery
+1217648,Acinetobacter beijerinckii CIP 110307,Acinetobacter beijerinckii,,periphery
+1217652,Acinetobacter brisouii ANC 4119,Acinetobacter brisouii,,periphery
+1217656,Acinetobacter guillouiae NIPH 991,Acinetobacter guillouiae,,periphery
+1217658,Acinetobacter gyllenbergii NIPH 230,Acinetobacter gyllenbergii,,periphery
+1217703,Acinetobacter sp. ANC 4105,Acinetobacter sp. ANC4105,,core
+1217705,Acinetobacter sp. ANC 3862,Acinetobacter sp. ANC3862,,periphery
+1217708,Acinetobacter sp. NIPH 2100,Acinetobacter sp. NIPH2100,,periphery
+1217710,Acinetobacter sp. NIPH 899,Acinetobacter sp. NIPH899,,periphery
+1217712,Acinetobacter sp. NIPH 758,Acinetobacter sp. NIPH758,,periphery
+1217713,Acinetobacter sp. NIPH 809,Acinetobacter sp. NIPH809,,periphery
+1217714,Acinetobacter sp. ANC 3789,Acinetobacter sp. ANC3789,,periphery
+1217715,Acinetobacter bohemicus ANC 3994,Acinetobacter bohemicus,,periphery
+1217718,Cupriavidus sp. BIS7,Cupriavidus sp. BIS7,,periphery
+1217720,Roseomonas sp. B5,Roseomonas sp. B5,,periphery
+1218074,Burkholderia acidipaludis NBRC 101816,Burkholderia acidipaludis,,periphery
+1218075,Burkholderia bannensis NBRC 103871,Burkholderia bannensis,,periphery
+1218076,Burkholderia ferrariae NBRC 106233,Burkholderia ferrariae,,periphery
+1218084,Burkholderia terrae NBRC 100964,Burkholderia terrae,,periphery
+1218086,Citrobacter sedlakii NBRC 105722,Citrobacter sedlakii,,periphery
+1218103,Chryseobacterium indologenes NBRC 14944,Chryseobacterium indologenes,,periphery
+1218108,Empedobacter brevis NBRC14943,Empedobacter brevis,,core
+1218173,Bacillus alcalophilus ATCC27647,Bacillus alcalophilus,,periphery
+1218352,Pseudomonas stutzeri KOS6,Pseudomonas stutzeri KOS6,,periphery
+1219031,Comamonas aquatica NBRC 14918,Comamonas aquatica,,periphery
+1219035,Novosphingobium tardaugens NBRC 16725,Novosphingobium tardaugens,,periphery
+1219045,Sphingobium herbicidovorans NBRC 16415,Sphingobium herbicidovorans,,periphery
+1219049,Sphingomonas parapaucimobilis NBRC 15100,Sphingomonas parapaucimobilis,,periphery
+1219065,Vibrio proteolyticus NBRC 13287,Vibrio proteolyticus,,periphery
+1219072,Vibrio halioticoli NBRC 102217,Vibrio halioticoli,,periphery
+1219076,Vibrio alginolyticus NBRC15630,Vibrio alginolyticus NBRC15630,,periphery
+1219077,Vibrio azureus NBRC 104587,Vibrio azureus,,periphery
+1219080,Vibrio ezurae NBRC 102218,Vibrio ezurae,,periphery
+1219084,Thermotoga hypogea NBRC 106472,Thermotoga hypogea,,periphery
+1219375,Xanthomonas cassavae CFBP 4642,Xanthomonas cassavae,,periphery
+1219581,Actinomyces sp. S4-C9,Actinomyces sp. S4C9,,periphery
+1219585,Arcanobacterium sp. S3PF19,Arcanobacterium sp. S3PF19,,periphery
+1219626,Peptostreptococcus sp. MV1,Peptostreptococcus sp. MV1,,periphery
+1220534,Methanobacterium sp. Maddingley MBC34,Methanobacterium sp. Maddingley,,periphery
+1220535,alpha proteobacterium IMCC14465,alpha proteobacterium IMCC14465,,core
+1220551,Staphylococcus chromogenes MU 970,Staphylococcus chromogenes,,periphery
+1220582,Rhizobium rubi NBRC 13261,Rhizobium rubi,,periphery
+1220583,Gordonia aichiensis NBRC 108223,Gordonia aichiensis,,periphery
+1220589,Lysinibacillus odysseyi 34hs-1 ,Lysinibacillus odysseyi,,periphery
+1221522,Pseudomonas fluorescens NCIMB 11764,Pseudomonas fluorescens NCIMB11764,,periphery
+1221537,Lactobacillus florum 2F,Lactobacillus florum,,periphery
+1223410,Altibacter lentus,Altibacter lentus,,core
+1223521,Comamonas granuli NBRC 101663,Comamonas granuli,,periphery
+1223523,Streptomyces mobaraensis NBRC13819,Streptomyces mobaraensis,,periphery
+1223542,Gordonia malaquae NBRC 108250,Gordonia malaquae,,periphery
+1223543,Gordonia paraffinivorans NBRC 108238,Gordonia paraffinivorans,,periphery
+1223544,Gordonia sihwensis NBRC 108236,Gordonia sihwensis,,periphery
+1223545,Gordonia soli NBRC 108243,Gordonia soli,,periphery
+1224136,Enterobacteriaceae bacterium LSJC7,Enterobacteriaceae bacterium LSJC7,,periphery
+1224163,Corynebacterium maris DSM45190,Corynebacterium maris,,periphery
+1224164,Corynebacterium vitaeruminis DSM20294,Corynebacterium vitaeruminis,,periphery
+1224318,Mangrovibacter sp. MFB070,Mangrovibacter sp. MFB070,,core
+1224746,Gluconobacter oxydans H24,Gluconobacter oxydans H24,,periphery
+1225184,Pantoea sp. A4,Pantoea sp. A4,,periphery
+1225785,Dickeya sp. DW 0440,Dickeya sp. DW 0440,,periphery
+1226322,Oscillibacter sp. KLE 1728,Oscillibacter sp. KLE1728,,periphery
+1226325,Clostridium sp. KLE 1755,Clostridium sp. KLE1755,,periphery
+1226994,Pseudomonas nitroreducens TX1,Pseudomonas nitroreducens TX1,,periphery
+1227261,Actinobaculum sp. oral taxon 183 str. F0552,Actinobaculum sp. F0552,,periphery
+1227266,Capnocytophaga sp. oral taxon 863 str. F0517,Capnocytophaga sp. F0517,,periphery
+1227268,Leptotrichia sp. oral taxon 879 str. F0557,Leptotrichia sp. F0557,,periphery
+1227272,Porphyromonas sp. oral taxon 278 str. W7784,Porphyromonas sp. W7784,,periphery
+1227276,Prevotella sp. F0091,Prevotella sp. F0091,,periphery
+1227349,Paenibacillus sp. FSL H7-689,Paenibacillus sp. FSLH7689,,periphery
+1227352,Paenibacillus sp. FSL R7-277,Paenibacillus sp. FSLR7277,,periphery
+1227360,Viridibacillus arenosi FSL R5-213,Viridibacillus arenosi,,core
+1227453,Haloarcula japonica DSM6131,Haloarcula japonica,,periphery
+1227454,Halobiforma nitratireducens JCM 10879,Halobiforma nitratireducens,,periphery
+1227457,Halococcus thailandensis JCM 13552,Halococcus thailandensis,,periphery
+1227484,Halorubrum saccharovorum DSM1137,Halorubrum saccharovorum,,periphery
+1227487,Halosarcina pallida JCM 14848,Halosarcina pallida,,periphery
+1227488,Haloterrigena salina JCM 13891,Haloterrigena salina,,periphery
+1227495,Natrinema pallidum DSM3751,Natrinema pallidum,,periphery
+1227497,Natronococcus amylolyticus DSM10524,Natronococcus amylolyticus,,periphery
+1227499,Natronolimnobius innermongolicus JCM 12255,Natronolimnobius innermongolicus,,periphery
+1227500,Natronorubrum bangense JCM 10635,Natronorubrum bangense,,periphery
+1227739,Hymenobacter swuensis DY53,Hymenobacter swuensis,,periphery
+1229172,Leptolyngbya sp. KIOST-1,Leptolyngbya sp. KIOST1,,core
+1229203,actinobacterium LLX17,actinobacterium LLX17,,core
+1229204,alpha proteobacterium L41A,alpha proteobacterium L41A,,periphery
+1229205,Burkholderia phenoliruptrix BR3459a,Burkholderia phenoliruptrix,,periphery
+1229276,Sphingobacterium sp. ACCC 05744,Sphingobacterium sp. ACCC05744,,periphery
+1229485,gamma proteobacterium WG36,Gammaproteobacteria bacterium WG36,,periphery
+1229487,Flavobacterium sp. WG21,Flavobacterium sp. WG21,,core
+1229512,Blattabacterium sp. (Panesthia angustipennis spadica),Blattabacterium sp. BPAA,,periphery
+1229517,Lactococcus garvieae I113,Lactococcus garvieae I113,,periphery
+1229520,Alkalibacterium sp. AK22,Alkalibacterium sp. AK22,,core
+1229756,Leuconostoc gelidum JB7,Leuconostoc gelidum JB7,,periphery
+1229758,Leuconostoc carnosum JB16,Leuconostoc carnosum,,periphery
+1229780,Candidatus Microthrix parvicella RN1,Microthrix parvicella,,core
+1229781,Brevibacterium casei S18,Brevibacterium casei,,periphery
+1229783,Staphylococcus massiliensis S46,Staphylococcus massiliensis,,periphery
+1229831,Chlamydia avium 10DC88,Chlamydia avium,,periphery
+1229909,Candidatus Nitrosopumilus sp. AR2,Nitrosopumilus sp. AR2,,periphery
+1230338,Moraxella macacae 0408225,Moraxella macacae,,periphery
+1230341,Salimicrobium sp. MJ3,Salimicrobium sp. MJ3,,core
+1230342,Clostridium tetanomorphum DSM665,Clostridium tetanomorphum,,periphery
+1230343,Legionella anisa str. Linanisette,Legionella anisa,,periphery
+1230457,Haloterrigena limicola JCM 13563,Haloterrigena limicola,,periphery
+1230460,Natronorubrum sulfidifaciens JCM 14089,Natronorubrum sulfidifaciens,,periphery
+1230476,Bradyrhizobium sp. DFCI-1,Bradyrhizobium sp. DFCI1,,periphery
+1231057,Paenisporosarcina sp. TG-14,Paenisporosarcina sp. TG14,,periphery
+1231185,Nitratireductor aquibiodomus NL21,Nitratireductor aquibiodomus,,periphery
+1231190,Nitratireductor indicus C115,Nitratireductor indicus,,periphery
+1231241,Thermotoga sp. Mc24,Thermotoga sp. Mc24,,periphery
+1231336,Lactobacillus shenzhenensis LY-73,Lactobacillus shenzhenensis,,periphery
+1231377,Lactococcus garvieae DCC43,Lactococcus garvieae DCC43,,periphery
+1231391,Pusillimonas noertemannii BS8,Pusillimonas noertemannii,,periphery
+1231392,Oceaniovalibus guishaninsula JLT2003,Oceaniovalibus guishaninsula,,core
+1231626,Cardinium endosymbiont cEper1 of Encarsia pergandiella,Cardinium endosymbiont cEper1,,periphery
+1232410,Desulfuromonas sp. TF,Desulfuromonas sp. TF,,core
+1232427,Corynebacterium sp. GD7,Corynebacterium sp. GD7,,periphery
+1232428,Megasphaera sp. NP3,Megasphaera sp. NP3,,periphery
+1232429,Nesterenkonia sp. NP1,Nesterenkonia sp. NP1,,periphery
+1232430,Nosocomiicoccus sp. NP2,Nosocomiicoccus sp. NP2,,core
+1232436,Coriobacteriaceae bacterium GD5,Coriobacteriaceae bacterium GD5,,periphery
+1232437,Desulfobacula sp. TS,Desulfobacula sp. TS,,core
+1232443,Clostridiales bacterium VE202-13,Clostridiales bacterium VE20213,,core
+1232446,Clostridiales bacterium VE202-18,Clostridiales bacterium VE20218,,periphery
+1232447,Clostridiales bacterium VE202-09,Clostridiales bacterium VE20209,,periphery
+1232449,Clostridiales bacterium VE202-08,Clostridiales bacterium VE20208,,periphery
+1232452,Clostridiales bacterium VE202-14,Clostridiales bacterium VE20214,,core
+1232453,Clostridiales bacterium VE202-21,Clostridiales bacterium VE20221,,periphery
+1232666,Staphylococcus sciuri subsp. sciuri Z8,Staphylococcus sciuri,,periphery
+1232683,Marinobacterium sp. AK27,Marinobacterium sp. AK27,,core
+1233950,Chryseobacterium sp. JM1,Chryseobacterium sp. JM1,,periphery
+1233951,Epilithonimonas sp. FH1,Epilithonimonas sp. FH1,,periphery
+1234364,Dyella ginsengisoli LA-4,Dyella ginsengisoli,,periphery
+1234409,Catellicoccus marimammalium M35/04/3,Catellicoccus marimammalium,,core
+1234593,Staphylococcus sp. E463,Staphylococcus sp. E463,,periphery
+1234595,alpha proteobacterium JLT2015,alpha proteobacterium JLT2015,,periphery
+1234664,Geobacillus caldoxylosilyticus CIC9,Geobacillus caldoxylosilyticus,,periphery
+1234679,Carnobacterium maltaromaticum LMA28,Carnobacterium maltaromaticum,,periphery
+1235279,Bhargavaea cecembensis DSE10,Bhargavaea cecembensis,,core
+1235457,Ralstonia sp. AU12-08,Ralstonia sp. AU1208,,periphery
+1235755,Salinicoccus carnicancri Crm,Salinicoccus carnicancri,,core
+1235788,Bacteroides massiliensis dnLKV3,Bacteroides massiliensis dnLKV3,,core
+1235790,Eubacterium sp. 14-2,Eubacterium sp. 142,,core
+1235792,Lachnospiraceae bacterium M18-1,Lachnospiraceae bacterium M181,,core
+1235793,Lachnospiraceae bacterium COE1,Lachnospiraceae bacterium COE1,,periphery
+1235794,Enterorhabdus caecimuris B7,Enterorhabdus caecimuris,,periphery
+1235796,Firmicutes bacterium M10-2,Firmicutes bacterium M102,,core
+1235797,Oscillibacter sp. 1-3,Oscillibacter sp. 13,,periphery
+1235798,Dorea sp. 5-2,Dorea sp. 52,,periphery
+1235799,Lachnospiraceae bacterium 3-2,Lachnospiraceae bacterium 32,,periphery
+1235800,Lachnospiraceae bacterium 10-1,Lachnospiraceae bacterium 101,,core
+1235801,Lactobacillus murinus ASF361,Lactobacillus murinus,,periphery
+1235802,Eubacterium plexicaudatum ASF492,Eubacterium plexicaudatum,,core
+1235803,Parabacteroides sp. ASF519,Parabacteroides sp. ASF519,,periphery
+1235811,Prevotella disiens JCM6334,Prevotella disiens JCM6334,,periphery
+1235813,Bacteroides pyogenes JCM 10003,Bacteroides pyogenes JCM10003,,periphery
+1235815,Prevotella enoeca JCM 12259,Prevotella enoeca,,periphery
+1235835,Anaerotruncus sp. G3(2012),Anaerotruncus sp. G3,,periphery
+1235990,Halyomorpha halys symbiont,Halyomorpha halys,,periphery
+1236494,Prevotella pleuritidis JCM 14110,Prevotella pleuritidis,,periphery
+1236497,Prevotella oulorum JCM 14966,Prevotella oulorum JCM14966,,periphery
+1236501,Acetobacter okinawensis JCM 25146,Acetobacter okinawensis,,periphery
+1236504,Prevotella histicola JCM15637,Prevotella histicola,,periphery
+1236508,Prevotella aurantiaca JCM 15754,Prevotella aurantiaca,,periphery
+1236514,Bacteroides stercorirosoris JCM 17103,Bacteroides stercorirosoris,,periphery
+1236517,Prevotella fusca JCM 17724,Prevotella fusca,,periphery
+1236518,Prevotella scopos JCM 17725,Prevotella scopos,,periphery
+1236541,Shewanella haliotis JCM 14758,Shewanella haliotis,,periphery
+1236542,Shewanella marina JCM 15074,Shewanella marina,,periphery
+1236689,Candidatus Methanomethylophilus alvus Mx1201,Methanomethylophilus alvus,,core
+1236902,Nocardiopsis baichengensis YIM 90130,Nocardiopsis baichengensis,,periphery
+1236908,Wolbachia endosymbiont of Drosophila simulans wNo,Wolbachia sp. Dsi,,periphery
+1236959,Methylobacillus glycogenes JCM 2850,Methylobacillus glycogenes,,periphery
+1236973,Bacillus akibai JCM 9157,Bacillus akibai,,periphery
+1236976,Paenibacillus pini JCM 16418,Paenibacillus pini,,periphery
+1237149,Fulvivirga imtechensis AK7,Fulvivirga imtechensis,,periphery
+1237500,Nocardiopsis ganjiahuensis DSM45031,Nocardiopsis ganjiahuensis,,periphery
+1238182,Caenispirillum salinarum AK4,Caenispirillum salinarum,,core
+1238184,Oceanobacillus kimchii X50,Oceanobacillus kimchii,,periphery
+1238186,Leucobacter salsicius M1-8,Leucobacter salsicius,,periphery
+1238190,Halomonas jeotgali Hwa,Halomonas jeotgali,,periphery
+1238237,Chlamydia psittaci 10_1398_11,Chlamydia psittaci 10139811,,periphery
+1238425,Haloquadratum walsbyi J07HQW2,Haloquadratum walsbyi J07HQW2,,periphery
+1238450,Vibrio nigripulchritudo SOn1,Vibrio nigripulchritudo,,periphery
+1239415,Dokdonia sp. PRO95,Dokdonia sp. PRO95,,periphery
+1239962,Mariniradius saccharolyticus AK6,Mariniradius saccharolyticus,,periphery
+1240349,Rhodococcus ruber Chol-4,Rhodococcus ruber,,periphery
+1240350,Pseudomonas putida MTCC 5279,Pseudomonas putida MTCC5279,,periphery
+1242864,Cystobacter fuscus DSM2262,Cystobacter fuscus,,periphery
+1242969,Campylobacter concisus ATCC51562,Campylobacter concisus ATCC51562,,periphery
+1243664,Bacillus sp. G2(2012b),Bacillus sp. G2,,periphery
+1244083,Campylobacter showae CSUNSWCD,Campylobacter showae CSUNSWCD,,periphery
+1244528,Campylobacter fetus subsp. testudinum 03-427,Campylobacter fetus testudinum,,periphery
+1244531,Campylobacter sp. 1485E,Campylobacter sp. 1485E,,periphery
+1244869,Magnetospirillum sp. SO-1,Magnetospirillum sp. SO1,,core
+1245469,Bradyrhizobium oligotrophicum S58,Bradyrhizobium oligotrophicum,,periphery
+1245471,Pseudomonas resinovorans NBRC 106553,Pseudomonas resinovorans NBRC106553,,periphery
+1245475,Nocardiopsis prasina DSM43845,Nocardiopsis prasina,,periphery
+1246445,Nocardiopsis kunsanensis DSM44524,Nocardiopsis kunsanensis,,periphery
+1246448,Nocardiopsis valliformis DSM45023,Nocardiopsis valliformis,,periphery
+1246459,Rhizobium sp. 2MFCol3.1,Rhizobium sp. 2MFCol31,,periphery
+1246474,Nocardiopsis xinjiangensis YIM 90004,Nocardiopsis xinjiangensis,,periphery
+1246484,Halobacillus sp. BAB-2008,Halobacillus sp. BAB2008,,core
+1246626,Bacillus lehensis G1,Bacillus lehensis,,periphery
+1246955,Mycoplasma cynos C142,Mycoplasma cynos,,periphery
+1246995,Actinoplanes friuliensis DSM7358,Actinoplanes friuliensis,,periphery
+1247024,Arsenophonus endosymbiont str. Hangzhou of Nilaparvata lugens,Arsenophonus endosymbiont,,core
+1247649,Bordetella holmesii ATCC51541,Bordetella holmesii,,periphery
+1247726,Advenella mimigardefordensis DPN7,Advenella mimigardefordensis,,periphery
+1247963,Parvularcula oceani,Parvularcula oceani,,periphery
+1248232,Photobacterium leiognathi lrivu.4.1,Photobacterium leiognathi lrivu41,,periphery
+1248760,Blastomonas sp. AAP53,Blastomonas sp. AAP53,,periphery
+1248916,Sandarakinorhabdus sp. AAP62,Sandarakinorhabdus sp. AAP62,,periphery
+1248917,Porphyrobacter sp. AAP82,Porphyrobacter sp. AAP82,,periphery
+1249480,Candidatus Sulfuricurvum sp. RIFRC-1,Sulfuricurvum sp. RIFRC1,,periphery
+1249627,Thiorhodococcus sp. AK35,Thiorhodococcus sp. AK35,,core
+1249634,Serratia marcescens FGI94,Serratia marcescens FGI94,,periphery
+1249975,Gillisia sp. Hel_I_29,Gillisia sp. HelI29,,core
+1249997,Maribacter sp. Hel_I_7,Maribacter sp. HelI7,,periphery
+1250005,Polaribacter sp. Hel1_85,Polaribacter sp. Hel185,,periphery
+1250006,Polaribacter sp. Hel_I_88,Polaribacter sp. HelI88,,periphery
+1250232,Muricauda sp. MAR_2010_75,Muricauda sp. MAR201075,,periphery
+1250278,Salegentibacter sp. Hel_I_6,Salegentibacter sp. HelI6,,core
+1254432,Sorangium cellulosum So0157-2,Sorangium cellulosum So01572,,periphery
+1255043,Thioalkalivibrio nitratireducens DSM14787,Thioalkalivibrio nitratireducens,,periphery
+1256908,Eubacterium ramulus ATCC29099,Eubacterium ramulus,,core
+1259795,Coprothermobacter platensis DSM11748,Coprothermobacter platensis,,periphery
+1260251,Spiribacter salinus M19-40,Spiribacter salinus,,core
+1260356,Enterococcus faecalis 13-SD-W-01,Enterococcus faecalis 13SDW01,,periphery
+1261131,Candidatus Liberibacter americanus str. Sao Paulo,Liberibacter americanus,,periphery
+1261545,Halarchaeum acidiphilum MH1-52-1,Halarchaeum acidiphilum,,periphery
+1262449,Clostridium pasteurianum DSM525,Clostridium pasteurianum DSM525,,periphery
+1262914,Phascolarctobacterium sp. CAG:207,Phascolarctobacterium sp. CAG207,,periphery
+1262915,Phascolarctobacterium sp. CAG:266,Phascolarctobacterium sp. CAG266,,periphery
+1263831,Bibersteinia trehalosi USDA-ARS-USMARC-189,Bibersteinia trehalosi,,periphery
+1265310,Mycobacterium asiaticum DSM44297,Mycobacterium asiaticum,,periphery
+1265313,Haliea rubra DSM19751,Haliea rubra,,periphery
+1265490,Pseudomonas sp. URMO17WK12:I8,Pseudomonas sp. URMO17WK12I8,,periphery
+1265502,Caldimonas manganoxidans ATCC BAA-369,Caldimonas manganoxidans,,core
+1265503,Colwellia piezophila ATCC BAA-637,Colwellia piezophila,,periphery
+1265505,Desulfospira joergensenii DSM10085,Desulfospira joergensenii,,core
+1265507,Succinimonas amylolytica DSM2873,Succinimonas amylolytica,,periphery
+1265756,Candidatus Pelagibacter ubique HTCC9022,Pelagibacter ubique HTCC9022,,periphery
+1265845,Listeria weihenstephanensis FSL R9-0317,Listeria weihenstephanensis,,periphery
+1266845,Carnobacterium sp. WN1359,Carnobacterium sp. WN1359,,core
+1266908,Thioalkalivibrio sp. ALE6,Thioalkalivibrio sp. ALE6,,periphery
+1266909,Thioalkalivibrio sp. ALE19,Thioalkalivibrio sp. ALE19,,periphery
+1266914,Thioalkalivibrio sp. AKL19,Thioalkalivibrio sp. AKL19,,periphery
+1266925,Nitrosospira briensis C-128,Nitrosospira briensis,,periphery
+1266998,Paracoccus zeaxanthinifaciens ATCC21588,Paracoccus zeaxanthinifaciens,,periphery
+1267003,Lactobacillus parabrevis ATCC53295,Lactobacillus parabrevis,,periphery
+1267005,Hyphomicrobium zavarzinii ATCC27496,Hyphomicrobium zavarzinii,,periphery
+1267211,Sediminibacterium sp. C3,Sediminibacterium sp. C3,,periphery
+1267533,Acidobacteriaceae bacterium KBS 83,Acidobacteriaceae bacterium KBS83,,periphery
+1267534,Acidobacteriaceae bacterium KBS 89,Acidobacteriaceae bacterium KBS89,,periphery
+1267535,Acidobacteriaceae bacterium KBS 96,Acidobacteriaceae bacterium KBS96,,periphery
+1267580,Anoxybacillus flavithermus TNO-09.006,Anoxybacillus flavithermus TNO09006,,core
+1267600,Pantoea sp. IMH,Pantoea sp. IMH,,periphery
+1268068,Pseudomonas sp. G5(2012),Pseudomonas sp. G5,,periphery
+1268072,Paenibacillus sabinae T27,Paenibacillus sabinae,,periphery
+1268237,Aeromonas diversa 2478-85,Aeromonas diversa,,periphery
+1268239,Pseudoalteromonas luteoviolacea B,Pseudoalteromonas luteoviolacea,,core
+1268240,Bacteroides cellulosilyticus WH2,Bacteroides cellulosilyticus,,periphery
+1268303,Rhodococcus sp. AW25M09,Rhodococcus sp. AW25M09,,periphery
+1268622,Acidovorax sp. MR-S7,Acidovorax sp. MRS7,,periphery
+1268635,Legionella oakridgensis ATCC33761,Legionella oakridgensis,,periphery
+1269813,Thioalkalivibrio sp. ALR17-21,Thioalkalivibrio sp. ALR1721,,periphery
+1270193,Flavobacterium sp. KJJ,Flavobacterium sp. KJJ,,core
+1270196,Pedobacter sp. R20-19,Pedobacter sp. R2019,,periphery
+1273103,Megasphaera sp. NM10,Megasphaera sp. NM10,,core
+1273125,Rhodococcus rhodnii LMG 5362,Rhodococcus rhodnii,,periphery
+1273538,Planomicrobium glaciei CHR43,Planomicrobium glaciei,,core
+1274374,Paenibacillus sp. GD11,Paenibacillus sp. GD11,,periphery
+1274402,Candidatus Hepatobacter penaei,Hepatobacter penaei,,periphery
+1274524,Bacillus sonorensis L12,Bacillus sonorensis,,periphery
+1276220,Spiroplasma taiwanense CT-1,Spiroplasma taiwanense,,periphery
+1276221,Spiroplasma diminutum CUAS-1,Spiroplasma diminutum,,core
+1276227,Spiroplasma chrysopicola DF-1,Spiroplasma chrysopicola,,periphery
+1276229,Spiroplasma syrphidicola EA-1,Spiroplasma syrphidicola,,periphery
+1276246,Spiroplasma culicicola AES-1,Spiroplasma culicicola,,core
+1276257,Spiroplasma sabaudiense Ar-1343,Spiroplasma sabaudiense,,periphery
+1276258,Spiroplasma apis B31,Spiroplasma apis,,periphery
+1276756,Acidovorax sp. JHL-9,Acidovorax sp. JHL9,,periphery
+1276920,Arthrobacter gangotriensis Lz1y,Arthrobacter gangotriensis,,periphery
+1278073,Myxococcus stipitatus DSM14675,Myxococcus stipitatus,,periphery
+1278078,Rhodococcus triatomae BKS 15-14,Rhodococcus triatomae,,periphery
+1278304,Acholeplasma granularum ATCC19168,Acholeplasma granularum,,periphery
+1278306,Fusobacterium russii ATCC25533,Fusobacterium russii,,core
+1278307,Psychromonas ossibalaenae ATCC BAA-1528,Psychromonas ossibalaenae,,periphery
+1278308,Zimmermannella faecalis ATCC13722,Zimmermannella faecalis,,periphery
+1278309,Amphritea japonica ATCC BAA-1530,Amphritea japonica,,core
+1278311,Acholeplasma axanthum ATCC25176,Acholeplasma axanthum,,periphery
+1278971,Avibacterium paragallinarum 221,Avibacterium paragallinarum 221,,periphery
+1279009,Cesiribacter andamanensis AMV16,Cesiribacter andamanensis,,periphery
+1279015,Oceanimonas smirnovii ATCC BAA-899,Oceanimonas smirnovii,,periphery
+1279017,Microbulbifer variabilis ATCC700307,Microbulbifer variabilis,,periphery
+1279019,Thioalkalivibrio thiocyanoxidans ARh2,Thioalkalivibrio thiocyanoxidans ARh2,,periphery
+1279038,Novispirillum itersonii subsp. itersonii ATCC12639,Novispirillum itersonii,,core
+1280001,Vibrio jasicida MWB 21,Vibrio jasicida,,periphery
+1280380,Synechococcus sp. KORDI-100,Synechococcus sp. KORDI100,,periphery
+1280390,Paenibacillaceae bacterium G5,Paenibacillaceae bacterium G5,,core
+1280663,Butyrivibrio sp. AE2015,Butyrivibrio sp. AE2015,,core
+1280664,Butyrivibrio sp. VCD2006,Butyrivibrio sp. VCD2006,,periphery
+1280666,Butyrivibrio sp. AE3009,Butyrivibrio sp. AE3009,,core
+1280668,Butyrivibrio sp. XPD2006,Butyrivibrio sp. XPD2006,,periphery
+1280671,Butyrivibrio sp. FC2001,Butyrivibrio sp. FC2001,,periphery
+1280673,Butyrivibrio sp. AE3006,Butyrivibrio sp. AE3006,,periphery
+1280674,Prevotella sp. AGR2160,Prevotella sp. AGR2160,,periphery
+1280676,Butyrivibrio sp. WCD3002,Butyrivibrio sp. WCD3002,,periphery
+1280679,Butyrivibrio sp. VCB2006,Butyrivibrio sp. VCB2006,,periphery
+1280680,Butyrivibrio sp. LC3010,Butyrivibrio sp. LC3010,,periphery
+1280681,Butyrivibrio sp. WCD2001,Butyrivibrio sp. WCD2001,,periphery
+1280682,Butyrivibrio sp. XBB1001,Butyrivibrio sp. XBB1001,,core
+1280685,Butyrivibrio sp. NC3005,Butyrivibrio sp. NC3005,,periphery
+1280686,Butyrivibrio sp. MC2013,Butyrivibrio sp. MC2013,,periphery
+1280688,Pseudobutyrivibrio ruminis CF1b,Pseudobutyrivibrio ruminis CF1b,,periphery
+1280689,Clostridium paraputrificum AGR2156,Clostridium paraputrificum,,periphery
+1280692,Clostridium cadaveris AGR2141,Clostridium cadaveris,,periphery
+1280694,Pseudobutyrivibrio ruminis AD2017,Pseudobutyrivibrio ruminis AD2017,,core
+1280696,Butyrivibrio fibrisolvens ND3005,Butyrivibrio fibrisolvens ND3005,,periphery
+1280698,Dorea longicatena AGR2136,Dorea longicatena AGR2136,,periphery
+1280706,Selenomonas ruminantium subsp. ruminantium ATCC12561,Selenomonas ruminantium ATCC12561,,periphery
+1280941,Hyphomonas sp. T16B2,Hyphomonas sp. T16B2,,periphery
+1280944,Hyphomonas sp. CY54-11-8,Hyphomonas sp. CY54118,,periphery
+1280946,Hyphomonas sp. 25B14_1,Hyphomonas sp. 25B141,,periphery
+1280947,Hyphomonas sp. BH-BN04-4,Hyphomonas sp. BHBN044,,periphery
+1280948,Hyphomonas sp. 22II1-22F38,Hyphomonas sp. 22II122F38,,periphery
+1280949,Hyphomonas adhaerens MHS-3,Hyphomonas adhaerens,,periphery
+1280950,Hyphomonas johnsonii MHS-2,Hyphomonas johnsonii,,periphery
+1280952,Hyphomonas jannaschiana VP2,Hyphomonas jannaschiana,,periphery
+1280953,Hyphomonas oceanitis SCH89,Hyphomonas oceanitis,,periphery
+1280954,Hyphomonas polymorpha PS728,Hyphomonas polymorpha,,periphery
+1281779,Agrobacterium tumefaciens str. Cherry 2E-2-2,Agrobacterium tumefaciens Cherry,,periphery
+1282356,Pseudomonas poae RE*1-1-14,Pseudomonas poae,,periphery
+1282360,Asticcacaulis sp. AC460,Asticcacaulis sp. AC460,,periphery
+1282361,Asticcacaulis sp. AC402,Asticcacaulis sp. AC402,,periphery
+1282362,Asticcacaulis sp. AC466,Asticcacaulis sp. AC466,,core
+1282664,Streptococcus tigurinus AZ_3a,Streptococcus tigurinus AZ3a,,periphery
+1282665,Streptococcus tigurinus 1366,Streptococcus tigurinus 1366,,periphery
+1282876,alpha proteobacterium Mf 1.05b.01,alpha proteobacterium Mf 105b01,,periphery
+1282887,Lachnospira multipara ATCC19207,Lachnospira multipara ATCC19207,,periphery
+1283283,Frankia sp. Iso899,Frankia sp. Iso899,,periphery
+1283284,Tolumonas sp. BRL6-1,Tolumonas sp. BRL61,,periphery
+1283287,Nocardioides sp. Iso805N,Nocardioides sp. Iso805N,,periphery
+1283299,Conexibacter woesei Iso977N,Conexibacter woesei Iso977N,,periphery
+1283300,Methylohalobius crimeensis 10Ki,Methylohalobius crimeensis,,core
+1284352,Paenibacillus sp. A9,Paenibacillus sp. A9,,periphery
+1284679,Actinomyces urogenitalis S6-C4,Actinomyces urogenitalis S6C4,,core
+1284680,Actinomyces sp. S6-Spd3,Actinomyces sp. S6Spd3,,periphery
+1284686,Anaerococcus lactolyticus S7-1-13,Anaerococcus lactolyticus S7113,,periphery
+1284708,Clostridiales bacterium S7-1-4,Clostridiales bacterium S714,,core
+1284775,Prevotella sp. S7-1-8,Prevotella sp. S718,,periphery
+1285583,Corynebacterium casei LMG S-19264,Corynebacterium casei,,periphery
+1285586,Lysinibacillus sphaericus OT4b.31,Lysinibacillus sphaericus OT4b31,,periphery
+1286093,Pandoraea sp. SD6-2,Pandoraea sp. SD62,,periphery
+1286106,Methylophaga lonarensis MPL,Methylophaga lonarensis,,periphery
+1286170,Raoultella ornithinolytica B6,Raoultella ornithinolytica,,core
+1286171,Eubacterium acidaminophilum DSM3953,Eubacterium acidaminophilum,,core
+1286631,Sphaerotilus natans subsp. natans DSM6575,Sphaerotilus natans,,core
+1286632,Zhouia amylolytica AD3,Zhouia amylolytica,,core
+1287116,Mesorhizobium sp. L2C084A000,Mesorhizobium sp. L2C084A000,,periphery
+1287276,Mesorhizobium sp. LNJC398B00,Mesorhizobium sp. LNJC398B00,,periphery
+1287475,Corynebacterium freneyi DNF00450,Corynebacterium freneyi,,periphery
+1287476,Prevotella bivia DNF00188,Prevotella bivia DNF00188,,core
+1287488,Prevotella sp. S7 MS 2,Prevotella sp. S7 MS 2,,core
+1288079,Streptomyces sp. CNT318,Streptomyces sp. CNT318,,periphery
+1288083,Streptomyces sp. TAA040,Streptomyces sp. TAA040,,periphery
+1288298,Roseovarius mucosus DSM17069,Roseovarius mucosus,,periphery
+1288484,Deinococcus wulumuqiensis R12,Deinococcus wulumuqiensis,,periphery
+1288494,Nitrosospira sp. APG3,Nitrosospira sp. APG3,,periphery
+1288826,Marinobacter santoriniensis NKSG1,Marinobacter santoriniensis,,periphery
+1288963,Cyclobacteriaceae bacterium AK24,Cyclobacteriaceae bacterium AK24,,periphery
+1289135,Brachyspira hampsonii 30446,Brachyspira hampsonii,,periphery
+1289387,Streptomyces sp. TAA204,Streptomyces sp. TAA204,,periphery
+1291050,[Clostridium] josui JCM 17888,Clostridium josui,,periphery
+1291743,Lactobacillus oryzae JCM 18671,Lactobacillus oryzae,,periphery
+1292020,Dietzia sp. UCD-THP,Dietzia sp. UCDTHP,,periphery
+1292033,Mycoplasma putrefaciens Mput9231,Mycoplasma putrefaciens Mput9231,,periphery
+1292034,Caulobacter crescentus OR37,Caulobacter crescentus OR37,,periphery
+1292035,[Clostridium] sordellii VPI 9048,Clostridium sordellii,,periphery
+1292373,Propionibacterium granulosum TM11,Propionibacterium granulosum,,periphery
+1293047,Halopiger sp. IIH2,Halopiger sp. IIH2,,periphery
+1293048,Halopiger sp. IIH3,Halopiger sp. IIH3,,periphery
+1293054,Halanaerobium saccharolyticum subsp. saccharolyticum DSM6643,Halanaerobium saccharolyticum,,periphery
+1293597,Lactobacillus equicursoris DSM19284,Lactobacillus equicursoris,,periphery
+1294142,Clostridium intestinale URNW,Clostridium intestinale,,periphery
+1294143,Pseudomonas denitrificans ATCC13867,Pseudomonas denitrificans,,periphery
+1294265,Bacillus boroniphilus JCM 21738,Bacillus boroniphilus,,periphery
+1294273,Roseibacterium elongatum DSM19469,Roseibacterium elongatum,,core
+1295642,Geobacillus stearothermophilus NUB3621,Geobacillus stearothermophilus,,periphery
+1296415,Aquimarina sp. SW150,Aquimarina sp. SW150,,periphery
+1296416,Aquimarina megaterium XH134,Aquimarina megaterium,,core
+1296990,Komagataeibacter xylinus E25,Komagataeibacter xylinus,,periphery
+1297534,Streptococcus dentisani 7746,Streptococcus dentisani 7746,,periphery
+1297569,Mesorhizobium metallidurans STM 2683,Mesorhizobium metallidurans,,periphery
+1297570,Mesorhizobium sp. STM 4661,Mesorhizobium sp. STM4661,,periphery
+1297581,Anoxybacillus flavithermus AK1,Anoxybacillus flavithermus AK1,,periphery
+1297617,Intestinimonas butyriciproducens,Intestinimonas butyriciproducens,,core
+1297742,Myxococcus sp. (contaminant ex DSM436),Myxococcus sp.,,periphery
+1297857,Streptococcus dentisani 7747,Streptococcus dentisani 7747,,periphery
+1297863,Afipia sp. OHSU_I-C4,Afipia sp. OHSUIC4,,periphery
+1297865,Bradyrhizobium sp. OHSU_III,Bradyrhizobium sp. OHSUIII,,periphery
+1298593,Thalassolituus oleivorans MIL-1,Thalassolituus oleivorans,,core
+1298598,Gracilibacillus boraciitolerans JCM 21714,Gracilibacillus boraciitolerans,,periphery
+1298608,Psychrobacter sp. JCM 18900,Psychrobacter sp. JCM18900,,periphery
+1298858,Mesorhizobium sp. URHA0056,Mesorhizobium sp. URHA0056,,periphery
+1298860,Microbacterium sp. URHA0036,Microbacterium sp. URHA0036,,periphery
+1298863,Marmoricola sp. URHB0036,Marmoricola sp. URHB0036,,periphery
+1298864,Mycobacterium sp. URHD0025,Mycobacterium sp. URHD0025,,periphery
+1298865,Alteromonas sp. ALT199,Alteromonas sp. ALT199,,periphery
+1298867,Bradyrhizobium sp. URHA0002,Bradyrhizobium sp. URHA0002,,periphery
+1298880,Streptomyces sp. TAA486,Streptomyces sp. TAA486,,periphery
+1298920,[Desulfotomaculum] guttoideum DSM4024,Desulfotomaculum guttoideum,,core
+1299327,Mycobacterium kansasii 732,Mycobacterium kansasii 732,,periphery
+1300143,Chryseobacterium oranimense G311,Chryseobacterium oranimense,,periphery
+1300150,Enterococcus mundtii QU 25,Enterococcus mundtii,,core
+1300345,Lysobacter dokdonensis DS-58,Lysobacter dokdonensis,,periphery
+1300350,Sulfitobacter donghicola DSW-25,Sulfitobacter donghicola,,periphery
+1301098,Pseudomonas knackmussii B13,Pseudomonas knackmussii,,periphery
+1301100,Clostridium sp. 01,Clostridium sp. 01,,periphery
+1302286,Lactobacillus namurensis str. Chizuka 01,Lactobacillus namurensis,,periphery
+1302858,Borrelia miyamotoi LB-2001,Borrelia miyamotoi,,periphery
+1302863,Streptococcus oligofermentans AS 1.3089,Streptococcus oligofermentans,,periphery
+1303518,Chthonomonas calidirosea T49,Chthonomonas calidirosea,,core
+1303692,Streptomyces fulvissimus DSM40593,Streptomyces fulvissimus,,periphery
+1304275,Salinisphaera hydrothermalis C41B8,Salinisphaera hydrothermalis,,periphery
+1304284,Clostridiaceae bacterium L21-TH-D2,Clostridiaceae bacterium L21THD2,,core
+1304865,Cellulomonas sp. KRMCY2,Cellulomonas sp. KRMCY2,,periphery
+1304866,Clostridium sp. ASBs410,Clostridium sp. ASBs410,,periphery
+1304872,Desulfovibrio cf. magneticus IFRC170,Desulfovibrio magneticus IFRC170,,periphery
+1304874,Aminiphilus circumscriptus DSM16581,Aminiphilus circumscriptus,,core
+1304875,Aminobacterium mobile DSM12262,Aminobacterium mobile,,periphery
+1304876,Arthrobacter nicotinovorans 231Sha2.1M6,Arthrobacter nicotinovorans,,periphery
+1304877,Bradyrhizobium japonicum 22,Bradyrhizobium japonicum 22,,periphery
+1304878,Bradyrhizobium japonicum in8p8,Bradyrhizobium japonicum in8p8,,periphery
+1304880,Caldicoprobacter oshimai DSM21659,Caldicoprobacter oshimai,,core
+1304883,Dechloromonas agitata is5,Dechloromonas agitata,,periphery
+1304885,Desulforegula conservatrix Mb1Pa,Desulforegula conservatrix,,core
+1304888,Geovibrio sp. L21-Ace-BES,Geovibrio sp. L21AceBES,,periphery
+1305732,Microbacterium sp. KROCY2,Microbacterium sp. KROCY2,,periphery
+1305735,Oceanicola sp. HL-35,Oceanicola sp. HL35,,periphery
+1305737,Algoriphagus marincola HL-49,Algoriphagus marincola HL49,,periphery
+1305836,Sporosarcina sp. EUR3 2.2.2,Sporosarcina sp. EUR3222,,core
+1306174,Kineosporia aurantiaca JCM 3230,Kineosporia aurantiaca,,periphery
+1306406,Streptomyces thermolilacinus SPC6,Streptomyces thermolilacinus,,periphery
+1306947,candidate division TM6 bacterium JCVI TM6SC1,candidate division TM6,,core
+1306990,Streptomyces sp. R1-NS-10,Streptomyces sp. R1NS10,,periphery
+1307436,Bacillus firmus DS1,Bacillus firmus,,periphery
+1307437,Pseudoalteromonas agarivorans S816,Pseudoalteromonas agarivorans,,core
+1307759,Desulfovibrio sp. L21-Syr-AB,Desulfovibrio sp. L21SyrAB,,periphery
+1307761,Spirochaeta sp. L21-RPul-D2,Spirochaeta sp. L21RPulD2,,core
+1307834,Gluconobacter frateurii NBRC 103465,Gluconobacter frateurii,,periphery
+1308866,Gracilibacillus halophilus YIM-C55.5,Gracilibacillus halophilus,,periphery
+1312954,Arthrobacter sp. Br18,Arthrobacter sp. Br18,,periphery
+1312959,Arthrobacter sp. H14,Arthrobacter sp. H14,,periphery
+1313172,Ilumatobacter coccineus YM16-304,Ilumatobacter coccineus,,periphery
+1313265,Thermocrinis sp. GBS,Thermocrinis sp. GBS,,periphery
+1313292,Borrelia coriaceae Co53,Borrelia coriaceae,,periphery
+1313293,Borrelia anserina BA2,Borrelia anserina,,periphery
+1313294,Borrelia parkeri SLO,Borrelia parkeri,,periphery
+1313301,Thermonema rossianum DSM10300,Thermonema rossianum,,core
+1313304,Chitinivibrio alkaliphilus ACht1,Chitinivibrio alkaliphilus,,periphery
+1313421,Aureispira sp. CCB-QB1,Aureispira sp. CCBQB1,,periphery
+1316408,Streptococcus sp. HSISM1,Streptococcus sp. HSISM1,,periphery
+1316444,Blattabacterium sp. (Nauphoeta cinerea),Blattabacterium sp. Nci,,periphery
+1316927,Pseudomonas corrugata CFBP 5454,Pseudomonas corrugata,,periphery
+1316932,Mannheimia haemolytica M42548,Mannheimia haemolytica M42548,,periphery
+1316936,Phaeospirillum fulvum MGU-K5,Phaeospirillum fulvum,,core
+1317118,Roseivivax sp. 22II-s10s,Roseivivax sp. 22IIs10s,,core
+1317122,Aquimarina sp. 22II-S11-z7,Aquimarina sp. 22IIS11z7,,core
+1317124,Thioclava sp. 13D2W-2,Thioclava sp. 13D2W2,,core
+1318617,Candidatus Mycoplasma girerdii,Mycoplasma girerdii,,periphery
+1318628,Marinobacter lipolyticus SM19,Marinobacter lipolyticus SM19,,periphery
+1319815,Cetobacterium somerae ATCC BAA-474,Cetobacterium somerae,,core
+1320556,Mesorhizobium sp. NBIMC_P2-C3,Mesorhizobium sp. NBIMCP2C3,,periphery
+1321372,Streptococcus suis EA1832.92,Streptococcus suis EA183292,,periphery
+1321773,Atopobium sp. oral taxon 810 str. F0209,Atopobium sp. F0209,,periphery
+1321774,Leptotrichia sp. oral taxon 225 str. F0581,Leptotrichia sp. F0581,,core
+1321775,Actinomyces sp. oral taxon 172 str. F0311,Actinomyces sp. F0311,,periphery
+1321778,Clostridiales bacterium oral taxon 876 str. F0540,Clostridiales bacterium F0540,,periphery
+1321779,Leptotrichia sp. oral taxon 215 str. W9775,Leptotrichia sp. W9775,,periphery
+1321781,Mitsuokella sp. oral taxon 131 str. W9106,Mitsuokella sp. W9106,,periphery
+1321782,Oribacterium sp. oral taxon 078 str. F0263,Oribacterium sp. F0263,,periphery
+1321784,Peptostreptococcaceae bacterium oral taxon 113 str. W5053,Peptostreptococcaceae bacterium W5053,,periphery
+1321786,Selenomonas sp. oral taxon 892 str. F0426,Selenomonas sp. F0426,,periphery
+1321814,Eubacterium brachy ATCC33089,Eubacterium brachy,,core
+1321815,Treponema lecithinolyticum ATCC700332,Treponema lecithinolyticum,,periphery
+1321820,Gemella bergeriae ATCC700627,Gemella bergeriae,,periphery
+1322246,Desulfovibrio piezophilus C1TLV30,Desulfovibrio piezophilus,,periphery
+1323361,Rhodococcus defluvii,Rhodococcus defluvii,,periphery
+1323663,Pseudomonas pelagia CL-AP6,Pseudomonas pelagia,,periphery
+1324957,Candidatus Halobonum tyrrellensis G22,Halobonum tyrrellensis,,periphery
+1325130,Helicobacter fennelliae MRY12-0050,Helicobacter fennelliae,,periphery
+1328313,Catenovulum agarivorans DS-2,Catenovulum agarivorans DS2,,core
+1329250,Weissella oryzae SG25,Weissella oryzae,,periphery
+1329516,Thermoactinomyces daqus,Thermoactinomyces daqus,,core
+1330700,Thermus caliditerrae,Thermus caliditerrae,,periphery
+1331060,Sphingobium lactosutens DS20,Sphingobium lactosutens,,periphery
+1331660,Acinetobacter haemolyticus MTCC 9819,Acinetobacter haemolyticus,,periphery
+1332071,Serratia fonticola AU-AP2C,Serratia fonticola AUAP2C,,periphery
+1333507,Pseudoalteromonas haloplanktis TB64,Pseudoalteromonas haloplanktis TB64,,periphery
+1333523,Salinarchaeum sp. Harcht-Bsk1,Salinarchaeum sp. HarchtBsk1,,periphery
+1333856,Pseudomonas stutzeri MF28,Pseudomonas stutzeri MF28,,periphery
+1333998,alpha proteobacterium MA2,alpha proteobacterium MA2,,core
+1334046,Kurthia huakuii LAM0618,Kurthia huakuii,,core
+1335757,Spiribacter sp. UAH-SP71,Spiribacter sp. UAHSP71,,periphery
+1335760,Sphingobium sp. YL23,Sphingobium sp. YL23,,periphery
+1336208,Roseomonas gilardii subsp. rosea ATCC BAA-691,Roseomonas gilardii,,periphery
+1336233,Shewanella waksmanii ATCC BAA-643,Shewanella waksmanii,,periphery
+1336234,Atopobacter phocae ATCC BAA-285,Atopobacter phocae,,core
+1336235,Rhizobium selenitireducens ATCC BAA-1503,Rhizobium selenitireducens,,periphery
+1336237,Pseudomonas flectens ATCC12775,Pseudomonas flectens,,periphery
+1336241,Eubacterium xylanophilum ATCC35991,Eubacterium xylanophilum,,core
+1336243,Microvirga flocculans ATCC BAA-817,Microvirga flocculans,,periphery
+1336245,Carnimonas nigrificans ATCC BAA-78,Carnimonas nigrificans,,periphery
+1336249,Rhizobium larrymoorei ATCC51759,Rhizobium larrymoorei,,periphery
+1336803,Polaribacter sp. Hel1_33_49,Polaribacter sp. Hel13349,,core
+1337093,Loktanella cinnabarina LL-001,Loktanella cinnabarina,,periphery
+1337936,Calothrix sp. 336/3,Calothrix sp. 3363,,periphery
+1338011,Elizabethkingia anophelis NUHP1,Elizabethkingia anophelis,,periphery
+1340434,Bacillus sp. UNC438CL73TsuS30,Bacillus sp. UNC438CL73TsuS30,,periphery
+1340493,Bryobacter aggregatus MPL3,Bryobacter aggregatus,,periphery
+1341151,Laceyella sacchari 1-1,Laceyella sacchari,,periphery
+1341155,Flavobacterium saliperosum S13,Flavobacterium saliperosum,,periphery
+1341157,Ruminococcus flavefaciens 007c,Ruminococcus flavefaciens 007c,,periphery
+1341181,Flavobacterium limnosediminis JC2902,Flavobacterium limnosediminis,,periphery
+1341646,Mycobacterium septicum DSM44393,Mycobacterium septicum,,periphery
+1341679,Acinetobacter indicus CIP 110367,Acinetobacter indicus,,periphery
+1341695,Bifidobacterium bombi DSM19703,Bifidobacterium bombi,,periphery
+1342299,Sulfitobacter sp. MM-124,Sulfitobacter sp. MM124,,periphery
+1342301,Sulfitobacter sp. NB-77,Sulfitobacter sp. NB77,,periphery
+1342302,Sulfitobacter sp. NB-68,Sulfitobacter sp. NB68,,periphery
+1343158,Saccharibacter sp. AM169,Saccharibacter sp. AM169,,periphery
+1343739,Palaeococcus pacificus DY20341,Palaeococcus pacificus,,core
+1343740,Streptomyces rapamycinicus NRRL 5491,Streptomyces rapamycinicus,,periphery
+1344012,Tatumella sp. NML 06-3099,Tatumella sp. NML063099,,periphery
+1345023,Exiguobacterium pavilionensis RW-2,Exiguobacterium pavilionensis,,periphery
+1345592,Helicobacter pylori SA213A,Helicobacter pylori SA213A,,periphery
+1345695,Clostridium saccharobutylicum DSM13864,Clostridium saccharobutylicum,,periphery
+1345697,Geobacillus sp. JF8,Geobacillus sp. JF8,,periphery
+1346330,Sphingobacterium paucimobilis HER1398,Sphingobacterium paucimobilis,,periphery
+1346791,Sphingobium ummariense RL-3,Sphingobium ummariense,,periphery
+1347086,Bacillus sp. EB01,Bacillus sp. EB01,,periphery
+1347087,Paucisalibacillus sp. EB02,Paucisalibacillus sp. EB02,,core
+1347342,Formosa agariphila KMM 3901,Formosa agariphila,,periphery
+1347368,Bacillus sp. FF3,Bacillus sp. FF3,,periphery
+1347369,Bacillus sp. FF4,Bacillus sp. FF4,,periphery
+1347392,Anaerosalibacter sp. ND1,Anaerosalibacter sp. ND1,,core
+1347393,Bacteroidaceae bacterium MS4,Bacteroidaceae bacterium MS4,,periphery
+1348114,Pseudoalteromonas sp. OCN003,Pseudoalteromonas sp. OCN003,,core
+1348338,Leifsonia rubra CMS 76R,Leifsonia rubra,,periphery
+1348583,Cellulophaga baltica 13,Cellulophaga baltica,,periphery
+1348635,Vibrio diazotrophicus NBRC 103148,Vibrio diazotrophicus,,periphery
+1348657,Thauera terpenica 58Eu,Thauera terpenica,,periphery
+1348662,Corynebacterium argentoratense DSM44202,Corynebacterium argentoratense,,periphery
+1348663,Kitasatospora cheerisanensis KCTC 2395,Kitasatospora cheerisanensis,,periphery
+1348908,Bacillus megaterium MSP20.1,Bacillus megaterium MSP201,,periphery
+1349767,Janthinobacterium agaricidamnosum NBRC102515,Janthinobacterium agaricidamnosum,,periphery
+1349785,Tenacibaculum maritimum NBRC 15946,Tenacibaculum maritimum,,periphery
+1349820,Arthrobacter sp. AK-YN10,Arthrobacter sp. AKYN10,,periphery
+1349822,Coprobacter fastidiosus NSB1,Coprobacter fastidiosus,,core
+1352941,Streptomyces niveus NCIMB 11891,Streptomyces niveus,,periphery
+1353276,Olleya marilimosa CAM030,Olleya marilimosa,,core
+1353528,Thioclava sp. DT23-4,Thioclava sp. DT234,,periphery
+1353529,Bacteriovorax sp. BSW11_IV,Bacteriovorax sp. BSW11IV,,periphery
+1353531,Ensifer sp. TW10,Ensifer sp. TW10,,periphery
+1353537,Thioclava pacifica DSM10166,Thioclava pacifica,,core
+1354300,Peptoniphilus sp. ChDC B134,Peptoniphilus sp. ChDC,,core
+1354303,Psychrobacter aquaticus CMS 56,Psychrobacter aquaticus,,periphery
+1354314,Cardinium endosymbiont cBtQ1 of Bemisia tabaci,Cardinium endosymbiont cBtQ1,,periphery
+1354722,Roseovarius sp. MCTG156(2b),Roseovarius sp. MCTG156,,periphery
+1355368,Arcobacter sp. AF1028,Arcobacter sp. AF1028,,periphery
+1355374,Arcobacter sp. AF1440,Arcobacter sp. AF1440,,periphery
+1356852,Hymenobacter sp. APR13,Hymenobacter sp. APR13,,core
+1356854,Alicyclobacillus acidoterrestris ATCC49025,Alicyclobacillus acidoterrestris,,periphery
+1357272,Pseudomonas syringae CC1417,Pseudomonas syringae CC1417,,periphery
+1357275,Pseudomonas syringae CC1513,Pseudomonas syringae CC1513,,periphery
+1357279,Pseudomonas syringae CC1557,Pseudomonas syringae CC1557,,periphery
+1357399,Helicobacter canis NCTC 12740,Helicobacter canis,,periphery
+1357400,Helicobacter macacae MIT 99-5501,Helicobacter macacae,,periphery
+1358423,Sphingobacterium antarcticus 4BY,Sphingobacterium antarcticus,,periphery
+1365176,Thermofilum sp. 1910b,Thermofilum sp. 1910b,,periphery
+1366046,Rhodobacteraceae bacterium HIMB11,Rhodobacteraceae bacterium HIMB11,,core
+1366050,Ralstonia pickettii DTP0602,Ralstonia pickettii DTP0602,,periphery
+1367491,Campylobacter coli 76339,Campylobacter coli 76339,,periphery
+1367847,Paracoccus aminophilus JCM 7686,Paracoccus aminophilus,,periphery
+1370120,Mycobacterium sp. UM_WGJ,Mycobacterium sp. UMWGJ,,periphery
+1370121,Mycobacterium sp. UM_WWY,Mycobacterium sp. UMWWY,,periphery
+1370122,Rhizobium undicola ORS992,Rhizobium undicola,,periphery
+1370125,Mycobacterium iranicum UM_TJL,Mycobacterium iranicum,,periphery
+1378168,Firmicutes bacterium ASF500,Firmicutes bacterium ASF500,,periphery
+1379270,Gemmatimonas sp. AP64,Gemmatimonas sp. AP64,,periphery
+1379281,Desulfonauticus sp. A7A,Desulfonauticus sp. A7A,,periphery
+1379698,candidate division ZIXI bacterium RBG-1,candidate division ZIXI,,core
+1379701,Sphingomonas sp. FUKUSWIS1,Sphingomonas sp. FUKUSWIS1,,periphery
+1379858,Mucispirillum schaedleri ASF457,Mucispirillum schaedleri,,periphery
+1380346,Streptomyces sp. URHA0041,Streptomyces sp. URHA0041,,periphery
+1380347,Geodermatophilaceae bacterium URHB0048,Geodermatophilaceae bacterium URHB0048,,periphery
+1380350,Mesorhizobium sp. URHC0008,Mesorhizobium sp. URHC0008,,periphery
+1380354,Cellulomonas sp. URHE0023,Cellulomonas sp. URHE0023,,periphery
+1380355,Bradyrhizobium sp. URHD0069,Bradyrhizobium sp. URHD0069,,periphery
+1380356,Blastococcus sp. URHD0036,Blastococcus sp. URHD0036,,periphery
+1380358,Halomonas sp. 23_GOM-1509m,Halomonas sp. 23GOM1509m,,periphery
+1380367,Sulfitobacter sp. 20_GPM-1509m,Sulfitobacter sp. 20GPM1509m,,core
+1380370,Intrasporangiaceae bacterium URHB0013,Intrasporangiaceae bacterium URHB0013,,periphery
+1380380,Ahrensia sp. 13_GOM-1096m,Ahrensia sp. 13GOM1096m,,periphery
+1380384,Tenacibaculum sp. 47A_GOM-205m,Tenacibaculum sp. 47AGOM205m,,core
+1380386,Mycobacterium sp. URHB0044,Mycobacterium sp. URHB0044,,periphery
+1380387,Alcanivorax sp. 43B_GOM-46m,Alcanivorax sp. 43BGOM46m,,periphery
+1380390,Solirubrobacterales bacterium URHD0059,Solirubrobacterales bacterium URHD0059,,periphery
+1380391,Dongia sp. URHE0060,Dongia sp. URHE0060,,core
+1380393,Geodermatophilaceae bacterium URHA0031,Geodermatophilaceae bacterium URHA0031,,core
+1380394,Rhodospirillales bacterium URHD0088,Rhodospirillales bacterium URHD0088,,core
+1380408,Anoxybacillus flavithermus subsp. yunnanensis str. E13,Anoxybacillus flavithermus yunnanensis,,periphery
+1380600,Flaviramulus ichthyoenteri Th78,Flaviramulus ichthyoenteri,,core
+1380763,Paenibacillus darwinianus,Paenibacillus darwinianus,,periphery
+1381123,Aliihoeflea sp. 2WW,Aliihoeflea sp. 2WW,,periphery
+1381751,Brevibacterium sp. VCM10,Brevibacterium sp. VCM10,,periphery
+1382230,Asaia platycodi SF2.1,Asaia platycodi SF21,,periphery
+1382303,Caulobacteraceae bacterium PMMR1,Caulobacteraceae bacterium PMMR1,,core
+1382304,Alicyclobacillus macrosporangiidus CPP55,Alicyclobacillus macrosporangiidus,,periphery
+1382305,Sporosarcina sp. D27,Sporosarcina sp. D27,,periphery
+1382306,Thermogemmatispora sp. PM5,Thermogemmatispora sp. PM5,,periphery
+1382315,Geobacillus vulcani PSS1,Geobacillus vulcani,,periphery
+1382356,Thermomicrobiales bacterium KI4,Thermomicrobiales sp. KI4,,periphery
+1382358,Anoxybacillus tepidamans PS2,Anoxybacillus tepidamans,,core
+1382359,Acidobacterium sp. PMMR2,Acidobacterium sp. PMMR2,,periphery
+1384049,Lysinibacillus manganicus DSM26584,Lysinibacillus manganicus,,periphery
+1384054,Arenimonas malthae CC-JY-1,Arenimonas malthae,,periphery
+1384056,Arenimonas metalli CF5-1,Arenimonas metalli,,periphery
+1384057,Lysinibacillus sinduriensis BLB-1,Lysinibacillus sinduriensis,,periphery
+1384065,Ruminococcus albus AD2013,Ruminococcus albus AD2013,,periphery
+1384066,Ruminococcus flavefaciens AE3010,Ruminococcus flavefaciens AE3010,,periphery
+1384484,Adlercreutzia equolifaciens DSM19450,Adlercreutzia equolifaciens,,periphery
+1385420,Francisella sp. W12-1067,Francisella sp. W121067,,periphery
+1385510,Pontibacillus halophilus JSM076056,Pontibacillus halophilus,,periphery
+1385511,Pontibacillus marinus BH030004,Pontibacillus marinus,,core
+1385512,Pontibacillus litoralis JSM 072002,Pontibacillus litoralis,,periphery
+1385513,Pontibacillus chungwhensis BH030062,Pontibacillus chungwhensis,,periphery
+1385514,Pontibacillus yanchengensis Y32,Pontibacillus yanchengensis,,core
+1385515,Lysobacter defluvii IMMIB APB-9,Lysobacter defluvii,,periphery
+1385517,Lysobacter daejeonensis GH1-9,Lysobacter daejeonensis,,periphery
+1385518,Knoellia flava TL1,Knoellia flava,,periphery
+1385519,Knoellia aerolata DSM18566,Knoellia aerolata,,periphery
+1385520,Knoellia sinensis KCTC 19936,Knoellia sinensis,,periphery
+1385521,Knoellia subterranea KCTC 19937,Knoellia subterranea,,periphery
+1385935,Leptolyngbya sp. Heron Island J,Leptolyngbya sp. Heron,,periphery
+1386089,Intrasporangium oryzae NRRL B-24470,Intrasporangium oryzae,,periphery
+1386969,Gordonia amicalis CCMA-559,Gordonia amicalis,,periphery
+1387197,Candidatus Schmidhempelia bombi str. Bimp,Schmidhempelia bombi,,periphery
+1387312,Methylophilus sp. OH31,Methylophilus sp. OH31,,periphery
+1388763,Pseudomonas mosselii SJ10,Pseudomonas mosselii,,periphery
+1389489,Leifsonia xyli subsp. cynodontis DSM46306,Leifsonia xyli cynodontis,,periphery
+1390370,Pseudomonas mendocina EGD-AQ5,Pseudomonas mendocina EGDAQ5,,periphery
+1391646,[Clostridium] bifermentans WYM,Clostridium bifermentans,,periphery
+1391647,Clostridium sp. Ade.TY,Clostridium sp. AdeTY,,periphery
+1392244,Pseudozyma brasiliensis,Pseudozyma brasiliensis,,periphery
+1392486,Prevotella sp. HUN102,Prevotella sp. HUN102,,periphery
+1392487,Eubacterium sp. AB3007,Eubacterium sp. AB3007,,core
+1392488,Leeuwenhoekiella sp. Hel_I_48,Leeuwenhoekiella sp. HelI48,,periphery
+1392489,Leeuwenhoekiella sp. MAR_2009_132,Leeuwenhoekiella sp. MAR2009132,,periphery
+1392490,Sediminibacter sp. Hel_I_10,Sediminibacter sp. HelI10,,core
+1392491,Ruminococcaceae bacterium AE2021,Ruminococcaceae bacterium AE2021,,core
+1392493,Lachnospiraceae bacterium AC2031,Lachnospiraceae bacterium AC2031,,periphery
+1392498,Maribacter forsetii DSM18668,Maribacter forsetii,,periphery
+1392501,Selenomonas ruminantium AC2024,Selenomonas ruminantium AC2024,,core
+1392502,Selenomonas ruminantium AB3002,Selenomonas ruminantium AB3002,,periphery
+1392540,Acinetobacter nectaris CIP 110549,Acinetobacter nectaris,,periphery
+1392838,Bordetella hinzii ATCC51730,Bordetella hinzii,,periphery
+1394175,Bifidobacterium sp. 7101,Bifidobacterium sp. 7101,,periphery
+1394176,Bifidobacterium sp. A11,Bifidobacterium sp. A11,,periphery
+1394178,Actinomadura madurae LIID-AJ290,Actinomadura madurae,,periphery
+1395513,Sporolactobacillus laevolacticus DSM442,Sporolactobacillus laevolacticus,,core
+1395516,Pseudomonas moraviensis R28-S,Pseudomonas moraviensis,,periphery
+1395571,Pseudomonas taeanensis MS-3,Pseudomonas taeanensis,,periphery
+1395587,Paenibacillus sp. MAEPY2,Paenibacillus sp. MAEPY2,,periphery
+1396141,Haloferula sp. BvORR071,Haloferula sp. BvORR071,,periphery
+1396418,Verrucomicrobium sp. BvORR034,Verrucomicrobium sp. BvORR034,,periphery
+1396858,Marinobacter sp. ES-1,Marinobacter sp. ES1,,periphery
+1397278,Leucobacter sp. PH1c,Leucobacter sp. PH1c,,core
+1397284,Serratia sp. H1n,Serratia sp. H1n,,periphery
+1397527,Alcanivorax sp. P2S70,Alcanivorax sp. P2S70,,periphery
+1397528,Halomonas sp. PBN3,Halomonas sp. PBN3,,periphery
+1397666,alpha proteobacterium RS24,alpha proteobacterium RS24,,periphery
+1397693,Exiguobacterium undae DSM14481,Exiguobacterium undae,,periphery
+1397696,Exiguobacterium marinum DSM16307,Exiguobacterium marinum,,periphery
+1397699,Exiguobacterium oxidotolerans JCM 12280,Exiguobacterium oxidotolerans,,periphery
+1398491,Borrelia valaisiana Tom4006,Borrelia valaisiana Tom4006,,periphery
+1399115,Exiguobacterium sp. MH3,Exiguobacterium sp. MH3,,core
+1399147,Holospora obtusa F1,Holospora obtusa,,periphery
+1399774,Enterobacter cloacae JD6301,Enterobacter cloacae JD6301,,periphery
+1400520,Lactobacillus fabifermentans T30PCM01,Lactobacillus fabifermentans,,periphery
+1400524,Candidatus Pelagibacter ubique HTCC7214,Pelagibacter ubique HTCC7214,,periphery
+1400525,Candidatus Pelagibacter ubique HTCC7217,Pelagibacter ubique HTCC7217,,periphery
+1401064,Corynebacterium tuscaniense DNF00037,Corynebacterium tuscaniense,,periphery
+1401065,Oligella urethralis DNF00040,Oligella urethralis,,periphery
+1401067,Veillonella montpellierensis DNF00314,Veillonella montpellierensis,,periphery
+1401078,Prevotella buccalis DNF00985,Prevotella buccalis DNF00985,,core
+1401328,Candidatus Endolissoclinum faulkneri L5,Endolissoclinum faulkneri L5,,periphery
+1402135,Sulfitobacter sp. H3,Sulfitobacter sp. H3,,periphery
+1403313,Bacillus simplex BA2H3,Bacillus simplex,,periphery
+1403819,Verrucomicrobium sp. BvORR106,Verrucomicrobium sp. BvORR106,,periphery
+1403946,Streptococcus anginosus DORA_7,Streptococcus anginosus DORA7,,periphery
+1403948,Varibaculum cambriense DORA_20,Varibaculum cambriense DORA20,,core
+1404245,Corynebacterium glycinophilum AJ 3170,Corynebacterium glycinophilum,,periphery
+1405296,Chlamydia suis MD56,Chlamydia suis,,periphery
+1405498,Staphylococcus simulans UMC-CNS-990,Staphylococcus simulans,,periphery
+1406840,Flavobacterium beibuense F44-8,Flavobacterium beibuense,,periphery
+1407650,Synechococcus sp. NKBG15041c,Synechococcus sp. NKBG15041c,,periphery
+1408164,Betaproteobacteria bacterium MOLA814,Betaproteobacteria bacterium MOLA814,,periphery
+1408224,Sinorhizobium americanum CCGM7,Sinorhizobium americanum,,periphery
+1408226,Vagococcus lutrae LBD1,Vagococcus lutrae,,core
+1408254,Brevibacillus panacihumi W25,Brevibacillus panacihumi,,periphery
+1408287,Fusobacterium nucleatum W1481,Fusobacterium nucleatum W1481,,periphery
+1408303,Bacillus sp. MB2021,Bacillus sp. MB2021,,periphery
+1408304,Butyrivibrio sp. FCS014,Butyrivibrio sp. FCS014,,periphery
+1408306,Butyrivibrio sp. MC2021,Butyrivibrio sp. MC2021,,periphery
+1408310,Prevotella sp. MA2016,Prevotella sp. MA2016,,periphery
+1408311,Oribacterium sp. FC2011,Oribacterium sp. FC2011,,periphery
+1408312,Pseudobutyrivibrio sp. LB2011,Pseudobutyrivibrio sp. LB2011,,periphery
+1408321,Lachnospiraceae bacterium AC2028,Lachnospiraceae bacterium AC2028,,periphery
+1408322,Lachnospiraceae bacterium AC3007,Lachnospiraceae bacterium AC3007,,periphery
+1408323,Lachnospiraceae bacterium MA2020,Lachnospiraceae bacterium MA2020,,periphery
+1408324,Lachnospiraceae bacterium MC2017,Lachnospiraceae bacterium MC2017,,periphery
+1408415,Acholeplasma equifetale ATCC29724,Acholeplasma equifetale,,periphery
+1408416,Acholeplasma hippikon ATCC29725,Acholeplasma hippikon,,periphery
+1408417,Acholeplasma modicum ATCC29102,Acholeplasma modicum,,periphery
+1408418,Acidiphilium angustum ATCC35903,Acidiphilium angustum,,periphery
+1408419,Acidocella facilis ATCC35904,Acidocella facilis,,periphery
+1408422,Alkaliphilus transvaalensis ATCC700919,Alkaliphilus transvaalensis,,periphery
+1408423,Anaerovibrio lipolyticus LB2005,Anaerovibrio lipolyticus,,core
+1408424,Bacillus bogoriensis ATCC BAA-922,Bacillus bogoriensis,,periphery
+1408427,Bartonella elizabethae ATCC49927,Bartonella elizabethae,,periphery
+1408428,Bilophila wadsworthia ATCC49260,Bilophila wadsworthia ATCC49260,,periphery
+1408433,Crocinitomix catalasitica ATCC23190,Crocinitomix catalasitica,,periphery
+1408436,[Eubacterium] cellulosolvens LD2006,Eubacterium cellulosolvens LD2006,,periphery
+1408437,Eubacterium desmolans ATCC43058,Eubacterium desmolans,,core
+1408438,Facklamia sourekii ATCC700629,Facklamia sourekii,,periphery
+1408439,Fusobacterium perfoetens ATCC29250,Fusobacterium perfoetens,,core
+1408442,Helicobacter pametensis ATCC51478,Helicobacter pametensis,,periphery
+1408444,Legionella fairfieldensis ATCC49588,Legionella fairfieldensis,,periphery
+1408445,Legionella sainthelensi ATCC35248,Legionella sainthelensi,,periphery
+1408452,Mycobacterium genavense ATCC51234,Mycobacterium genavense,,periphery
+1408473,Prolixibacter bellariivorans ATCC BAA-1284,Prolixibacter bellariivorans,,core
+1408813,Sphingobacterium sp. H1ai,Sphingobacterium sp. H1ai,,periphery
+1408823,[Clostridium] mangenotii TR,Clostridium mangenotii,,periphery
+1410608,Bacteroides sp. Ga6A2,Bacteroides sp. Ga6A2,,periphery
+1410609,Treponema sp. C6A8,Treponema sp. C6A8,,periphery
+1410612,Oribacterium sp. P6A1,Oribacterium sp. P6A1,,periphery
+1410613,Prevotella sp. P6B1,Prevotella sp. P6B1,,periphery
+1410616,Pseudobutyrivibrio sp. MD2005,Pseudobutyrivibrio sp. MD2005,,core
+1410617,Ruminococcus sp. FC2018,Ruminococcus sp. FC2018,,periphery
+1410618,Selenomonas sp. ND2010,Selenomonas sp. ND2010,,core
+1410619,Serratia sp. DD3,Serratia sp. DD3,,periphery
+1410620,Shinella sp. DD12,Shinella sp. DD12,,periphery
+1410622,Lachnospiraceae bacterium C6A11,Lachnospiraceae bacterium C6A11,,periphery
+1410624,Lachnospiraceae bacterium FE2018,Lachnospiraceae bacterium FE2018,,periphery
+1410625,Lachnospiraceae bacterium MD2004,Lachnospiraceae bacterium MD2004,,core
+1410626,Lachnospiraceae bacterium NC2004,Lachnospiraceae bacterium NC2004,,periphery
+1410628,Lachnospiraceae bacterium ND2006,Lachnospiraceae bacterium ND2006,,periphery
+1410630,Lachnospiraceae bacterium P6A3,Lachnospiraceae bacterium P6A3,,periphery
+1410631,Lachnospiraceae bacterium P6B14,Lachnospiraceae bacterium P6B14,,periphery
+1410632,Lachnospiraceae bacterium V9D3004,Lachnospiraceae bacterium V9D3004,,periphery
+1410633,Lachnospiraceae bacterium YSB2008,Lachnospiraceae bacterium YSB2008,,periphery
+1410634,Propionibacteriaceae bacterium P6A17,Propionibacteriaceae bacterium P6A17,,core
+1410638,Ruminococcaceae bacterium AB4001,Ruminococcaceae bacterium AB4001,,periphery
+1410650,Butyrivibrio proteoclasticus P6B7,Butyrivibrio proteoclasticus P6B7,,periphery
+1410653,Clostridium lundense DSM17049,Clostridium lundense,,periphery
+1410658,Kandleria vitulina MC3001,Kandleria vitulina,,core
+1410661,Lachnospira multipara LB2003,Lachnospira multipara LB2003,,core
+1410665,Mitsuokella jalaludinii DSM13811,Mitsuokella jalaludinii,,periphery
+1410666,Prevotella brevis P6B11,Prevotella brevis,,periphery
+1410668,Proteiniclasticum ruminis DSM24773,Proteiniclasticum ruminis,,core
+1410670,Ruminococcus flavefaciens MA2007,Ruminococcus flavefaciens MA2007,,periphery
+1410674,Sharpea azabuensis DSM18934,Sharpea azabuensis,,core
+1410676,Succinivibrio dextrinosolvens H5,Succinivibrio dextrinosolvens,,periphery
+1411123,Rhizobiales bacterium YIM 77505,Rhizobiales bacterium YIM77505,,core
+1411685,Gammaproteobacteria bacterium MOLA455,Gammaproteobacteria bacterium MOLA455,,periphery
+1414719,Corynebacterium sp. JCB,Corynebacterium sp. JCB,,periphery
+1414720,Clostridium sp. JCC,Clostridium sp. JCC,,periphery
+1415166,Nocardia nova SH22a,Nocardia nova,,periphery
+1415630,Pseudomonas sp. TKP,Pseudomonas sp. TKP,,periphery
+1415754,Marinobacter sp. MCTG268,Marinobacter sp. MCTG268,,core
+1415755,Halomonas sp. TG39a,Halomonas sp. TG39a,,periphery
+1415756,Oceanicola sp. MCTG156(1a),Oceanicola sp. MCTG156,,periphery
+1415774,Clostridium botulinum 202F,Clostridium botulinum 202F,,periphery
+1415775,Clostridium baratii str. Sullivan,Clostridium baratii,,periphery
+1415778,Porticoccus hydrocarbonoclasticus MCTG13d,Porticoccus hydrocarbonoclasticus,,core
+1415779,Polycyclovorans algicola TG408,Polycyclovorans algicola,,core
+1415780,Algiphilus aromaticivorans DG1253,Algiphilus aromaticivorans,,core
+1416752,Microbacterium paraoxydans DH1b,Microbacterium paraoxydans DH1b,,periphery
+1416759,Leifsonia aquatica H1aii,Leifsonia aquatica,,periphery
+1416760,Myroides odoratimimus H1bi,Myroides odoratimimus,,periphery
+1417230,Borrelia persica No12,Borrelia persica,,periphery
+1417296,Defluviimonas sp. 20V17,Defluviimonas sp. 20V17,,core
+1419583,Pseudomonas mandelii PD30,Pseudomonas mandelii PD30,,periphery
+1419814,Streptococcus sp. VT 162,Streptococcus sp. VT 162,,periphery
+1423144,Phaeobacter gallaeciensis DSM26640,Phaeobacter gallaeciensis,,periphery
+1423321,Bacillus sp. SJS,Bacillus sp. SJS,,periphery
+1423724,Lactobacillus apodemi DSM16634,Lactobacillus apodemi,,periphery
+1423732,Lactobacillus casei DSM20011,Lactobacillus casei DSM20011,,periphery
+1423734,Lactobacillus composti DSM18527 ,Lactobacillus composti,,periphery
+1423743,Lactobacillus farraginis DSM18382,Lactobacillus farraginis,,periphery
+1423747,Lactobacillus fuchuensis DSM14340,Lactobacillus fuchuensis,,periphery
+1423748,Lactobacillus gallinarum DSM10532,Lactobacillus gallinarum,,periphery
+1423754,Lactobacillus hamsteri DSM5661,Lactobacillus hamsteri,,periphery
+1423755,Lactobacillus hayakitensis DSM18933,Lactobacillus hayakitensis,,periphery
+1423758,Lactobacillus hominis DSM23910,Lactobacillus hominis,,periphery
+1423767,Lactobacillus kitasatonis DSM16761,Lactobacillus kitasatonis,,periphery
+1423775,Lactobacillus nodensis DSM19682,Lactobacillus nodensis,,periphery
+1423780,Lactobacillus otakiensis DSM19908,Lactobacillus otakiensis,,periphery
+1423790,Lactobacillus pasteurii DSM23907,Lactobacillus pasteurii,,periphery
+1423806,Lactobacillus sucicola DSM21376,Lactobacillus sucicola,,periphery
+1423807,Lactobacillus suebicus DSM5007,Lactobacillus suebicus,,periphery
+1423814,Lactobacillus vaginalis DSM5837,Lactobacillus vaginalis,,periphery
+1423815,Lactobacillus versmoldensis DSM14857,Lactobacillus versmoldensis,,periphery
+1423816,Lactobacillus zeae DSM20178,Lactobacillus zeae,,periphery
+1424334,Advenella kashmirensis W13003,Advenella kashmirensis W13003,,periphery
+1427984,Candidatus Hepatoplasma crinochetorum Av,Hepatoplasma crinochetorum,,core
+1429046,Rhodococcus rhodochrous ATCC21198,Rhodococcus rhodochrous,,periphery
+1429851,Stenotrophomonas maltophilia 5BA-I-2,Stenotrophomonas maltophilia 5BAI2,,periphery
+1429916,Afipia sp. P52-10,Afipia sp. P5210,,periphery
+1430331,Geobacillus sp. G1w1,Geobacillus sp. G1w1,,periphery
+1430440,Magnetospirillum gryphiswaldense MSR-1 v2,Magnetospirillum gryphiswaldense,,periphery
+1432050,Rhizobium etli bv. mimosae str. IE4771,Rhizobium etli mimosae,,periphery
+1432055,Komagataeibacter rhaeticus AF1,Komagataeibacter rhaeticus,,periphery
+1432056,Mannheimia varigena USDA-ARS-USMARC-1261,Mannheimia varigena USMARC1261,,periphery
+1433126,Rikenellaceae bacterium M3,Rikenellaceae bacterium M3,,core
+1433287,Mannheimia varigena USDA-ARS-USMARC-1296,Mannheimia varigena USMARC1296,,periphery
+1434325,Dyadobacter tibetensis Y620-1,Dyadobacter tibetensis,,periphery
+1434929,Burkholderia pseudomallei ABCPW 111,Burkholderia pseudomallei ABCPW111,,periphery
+1435051,Bifidobacterium moukalabense DSM27321,Bifidobacterium moukalabense,,periphery
+1435356,Rhodococcus pyridinivorans SB3094,Rhodococcus pyridinivorans,,periphery
+1437425,Criblamydia sequanensis CRIB-18,Criblamydia sequanensis,,core
+1437448,Ochrobactrum rhizosphaerae SJY1,Ochrobactrum rhizosphaerae,,periphery
+1437600,Bifidobacterium pullorum DSM20433,Bifidobacterium pullorum,,periphery
+1437603,Bifidobacterium mongoliense DSM21395,Bifidobacterium mongoliense,,periphery
+1437605,Bifidobacterium actinocoloniiforme DSM22766,Bifidobacterium actinocoloniiforme,,periphery
+1437606,Bifidobacterium bohemicum DSM22767,Bifidobacterium bohemicum,,periphery
+1437608,Bifidobacterium biavatii DSM23969,Bifidobacterium biavatii,,periphery
+1437609,Bifidobacterium callitrichos DSM23973,Bifidobacterium callitrichos,,periphery
+1437610,Bifidobacterium reuteri DSM23975,Bifidobacterium reuteri,,periphery
+1437824,Castellaniella defragrans 65Phen,Castellaniella defragrans,,periphery
+1437882,Pseudomonas nitroreducens HBP1,Pseudomonas nitroreducens HBP1,,periphery
+1439940,Pseudomonas sp. BAY1663,Pseudomonas sp. BAY1663,,periphery
+1440052,Escherichia albertii KF1,Escherichia albertii KF1,,periphery
+1440053,Streptomyces scopuliridis RB72,Streptomyces scopuliridis,,periphery
+1440774,Mycobacterium aromaticivorans JS19b1,Mycobacterium aromaticivorans,,periphery
+1441629,Pseudomonas cichorii JBC1,Pseudomonas cichorii,,periphery
+1441930,Serratia fonticola RB-25,Serratia fonticola RB25,,periphery
+1442598,Arcobacter cibarius LMG 21996,Arcobacter cibarius,,periphery
+1442599,Luteimonas huabeiensis HB2,Luteimonas huabeiensis,,periphery
+1443111,Sulfitobacter guttiformis KCTC 32187,Sulfitobacter guttiformis,,periphery
+1443113,Yersinia enterocolitica LC20,Yersinia enterocolitica LC20,,periphery
+1443122,Clostridium novyi B str. NCTC9691,Clostridium novyi B NCTC9691,,periphery
+1443125,Clostridium botulinum C/D str. BKT12695,Clostridium botulinum CD BKT12695,,periphery
+1443665,Aquimarina macrocephali JAMB N27,Aquimarina macrocephali,,periphery
+1444306,Sporolactobacillus terrae DSM11697,Sporolactobacillus terrae,,periphery
+1444309,Brevibacillus borstelensis 3096-7,Brevibacillus borstelensis,,periphery
+1444310,Bacillus flexus T6186-2,Bacillus flexus,,periphery
+1444711,Chlamydia sp. 'Diamant',Chlamydia sp. Diamant,,periphery
+1444712,Chlamydia sp. 'Rubis',Chlamydia sp. Rubis,,periphery
+1444770,Xylella fastidiosa PLS229,Xylella fastidiosa PLS229,,periphery
+1445613,Sciscionella sp. SE31,Sciscionella sp. SE31,,periphery
+1446473,Paracoccus yeei ATCC BAA-599,Paracoccus yeei,,periphery
+1448139,Aeromonas hydrophila YL17,Aeromonas hydrophila YL17,,periphery
+1448389,Tomitella biformata AHU 1821,Tomitella biformata,,periphery
+1448857,Campylobacter sp. CIT045,Campylobacter sp. CIT045,,periphery
+1448860,Halobellus rufus,Halobellus rufus,,periphery
+1449044,Arthrobacter sp. UNC362MFTsu5.1,Arthrobacter sp. UNC362MFTsu51,,periphery
+1449048,Mycobacterium sp. UNC280MFTsu5.1,Mycobacterium sp. UNC280MFTsu51,,periphery
+1449049,Caulobacter sp. UNC358MFTsu5.1,Caulobacter sp. UNC358MFTsu51,,periphery
+1449050,Clostridium sp. KNHs205,Clostridium sp. KNHs205,,periphery
+1449058,Microbacterium sp. UNCCL10,Microbacterium sp. UNCCL10,,periphery
+1449063,Paenibacillus sp. UNC451MF,Paenibacillus sp. UNC451MF,,periphery
+1449065,Phyllobacterium sp. UNC302MFCol5.2,Phyllobacterium sp. UNC302MFCol52,,periphery
+1449068,Rhodococcus sp. UNC23MFCrub1.1,Rhodococcus sp. UNC23MFCrub11,,periphery
+1449069,Rhodococcus sp. UNC363MFTsu5.1,Rhodococcus sp. UNC363MFTsu51,,periphery
+1449076,Sphingomonas sp. UNC305MFCol5.2,Sphingomonas sp. UNC305MFCol52,,periphery
+1449080,Thermus sp. YIM 77409,Thermus sp. YIM77409,,periphery
+1449126,Clostridiales bacterium DRI-13,Clostridiales bacterium DRI13,,periphery
+1449335,Carnobacterium alterfunditum DSM5972,Carnobacterium alterfunditum,,core
+1449336,Carnobacterium divergens DSM20623,Carnobacterium divergens,,periphery
+1449337,Carnobacterium funditum DSM5970,Carnobacterium funditum,,periphery
+1449338,Carnobacterium gallinarum DSM4847,Carnobacterium gallinarum,,periphery
+1449342,Carnobacterium mobile DSM4848,Carnobacterium mobile,,periphery
+1449343,Carnobacterium pleistocenium FTR1,Carnobacterium pleistocenium,,periphery
+1449345,Helicobacter rodentium ATCC700285,Helicobacter rodentium,,periphery
+1449346,Kitasatospora azatica KCTC 9699,Kitasatospora azatica,,periphery
+1449347,Kitasatospora mediocidica KCTC 9733,Kitasatospora mediocidica,,periphery
+1449350,Roseivivax halodurans JCM 10272,Roseivivax halodurans,,periphery
+1449351,Roseivivax isoporae LMG 25204,Roseivivax isoporae,,periphery
+1449353,Streptacidiphilus oryzae TH49,Streptacidiphilus oryzae,,periphery
+1449355,Streptomyces yeochonensis CN732,Streptomyces yeochonensis,,periphery
+1449357,Thermus tengchongensis YIM 77401,Thermus tengchongensis,,periphery
+1449976,Kutzneria albida DSM43870,Kutzneria albida,,periphery
+1450525,Flavobacterium succinicans LMG 10402,Flavobacterium succinicans,,periphery
+1450694,Bacillus sp. TS-2,Bacillus sp. TS2,,periphery
+1451189,Corynebacterium falsenii DSM44353,Corynebacterium falsenii,,periphery
+1451261,Microbacterium sp. MRS-1,Microbacterium sp. MRS1,,periphery
+1452535,Microbacterium sp. Cr-K32,Microbacterium sp. CrK32,,periphery
+1452536,Microbacterium sp. Cr-K20,Microbacterium sp. CrK20,,periphery
+1452718,Pseudomonas sp. RL,Pseudomonas sp. RL,,periphery
+1453496,Hafnia alvei FB1,Hafnia alvei,,core
+1453498,Flavobacterium aquatile LMG 4008,Flavobacterium aquatile,,periphery
+1453500,Schleiferia thermophila str. Yellowstone,Schleiferia thermophila,,core
+1453501,Microbulbifer sp. HZ11,Microbulbifer sp. HZ11,,core
+1453503,Pseudomonas pseudoalcaligenes AD6,Pseudomonas pseudoalcaligenes AD6,,periphery
+1453505,Flavobacterium chungangense LMG 26729,Flavobacterium chungangense,,periphery
+1454004,Candidatus Accumulibacter sp. BA-93,Accumulibacter sp. BA93,,periphery
+1454007,Pedobacter borealis DSM19626,Pedobacter borealis,,periphery
+1454010,Cellulomonas sp. HZM,Cellulomonas sp. HZM,,core
+1454202,Photobacterium phosphoreum ANT220,Photobacterium phosphoreum,,periphery
+1455608,Haladaptatus cibarius D43,Haladaptatus cibarius,,periphery
+1457250,Halapricum salinum,Halapricum salinum,,periphery
+1457393,Acetobacter aceti 1023,Acetobacter aceti 1023,,periphery
+1458275,Hylemonella gracilis str. Niagara R,Hylemonella gracilis Niagara,,periphery
+1458357,Burkholderia sp. MP-1,Burkholderia sp. MP1,,periphery
+1458427,Comamonadaceae bacterium H1,Comamonadaceae bacterium H1,,core
+1458462,Lachnospiraceae bacterium AC2029,Lachnospiraceae bacterium AC2029,,periphery
+1459636,Candidatus Nitrososphaera evergladensis SR1,Nitrososphaera evergladensis,,core
+1460634,Geomicrobium sp. JCM 19037,Geomicrobium sp. JCM19037,,periphery
+1460635,Geomicrobium sp. JCM 19038,Geomicrobium sp. JCM19038,,core
+1460640,Bacillus sp. JCM 19046,Bacillus sp. JCM19046,,periphery
+1461577,Weeksella sp. FF8,Weeksella sp. FF8,,periphery
+1461579,Haemophilus sp. FF7,Haemophilus sp. FF7,,periphery
+1461580,Bacillus sp. JCE,Bacillus sp. JCE,,periphery
+1461582,Jeotgalicoccus sp. 13MG44_air,Jeotgalicoccus sp. 13MG44air,,core
+1461693,Actibacterium atlanticum,Actibacterium atlanticum,,core
+1461694,Oceanicola sp. 22II-S11g,Oceanicola sp. 22IIS11g,,core
+1462526,Virgibacillus sp. Vm-5,Virgibacillus sp. Vm5,,periphery
+1462527,Oceanobacillus sp. S5,Oceanobacillus sp. S5,,periphery
+1463820,Actinosporangium sp. NRRL B-3428,Actinosporangium sp. NRRLB3428,,periphery
+1463821,Glycomyces sp. NRRL B-16210,Glycomyces sp. NRRLB16210,,periphery
+1463825,Saccharothrix sp. NRRL B-16314,Saccharothrix sp. NRRLB16314,,periphery
+1463841,Streptomyces sp. NRRL F-2580,Streptomyces sp. NRRLF2580,,periphery
+1463845,Streptomyces sp. NRRL F-2890,Streptomyces sp. NRRLF2890,,periphery
+1463853,Streptomyces sp. NRRL F-5008,Streptomyces sp. NRRLF5008,,periphery
+1463854,Streptomyces sp. NRRL F-5053,Streptomyces sp. NRRLF5053,,periphery
+1463855,Streptomyces sp. NRRL F-5065,Streptomyces sp. NRRLF5065,,periphery
+1463856,Streptomyces sp. NRRL F-5123,Streptomyces sp. NRRLF5123,,periphery
+1463857,Streptomyces sp. NRRL F-5126,Streptomyces sp. NRRLF5126,,periphery
+1463858,Streptomyces sp. NRRL F-5135,Streptomyces sp. NRRLF5135,,periphery
+1463861,Streptomyces sp. NRRL F-525,Streptomyces sp. NRRLF525,,periphery
+1463864,Streptomyces sp. NRRL F-5630,Streptomyces sp. NRRLF5630,,periphery
+1463879,Streptomyces sp. NRRL F-6677,Streptomyces sp. NRRLF6677,,periphery
+1463881,Streptomyces sp. NRRL S-118,Streptomyces sp. NRRLS118,,periphery
+1463885,Streptomyces sp. NRRL S-149,Streptomyces sp. NRRLS149,,periphery
+1463887,Streptomyces sp. NRRL S-1777,Streptomyces sp. NRRLS1777,,periphery
+1463895,Streptomyces sp. NRRL S-237,Streptomyces sp. NRRLS237,,periphery
+1463900,Streptomyces sp. NRRL S-337,Streptomyces sp. NRRLS337,,periphery
+1463901,Streptomyces sp. NRRL S-340,Streptomyces sp. NRRLS340,,periphery
+1463903,Streptomyces sp. NRRL S-37,Streptomyces sp. NRRLS37,,periphery
+1463909,Streptomyces sp. NRRL S-474,Streptomyces sp. NRRLS474,,periphery
+1463917,Streptomyces sp. NRRL S-646,Streptomyces sp. NRRLS646,,periphery
+1463920,Streptomyces sp. NRRL S-87,Streptomyces sp. NRRLS87,,periphery
+1463921,Streptomyces sp. NRRL S-920,Streptomyces sp. NRRLS920,,periphery
+1463926,Streptomyces sp. NRRL WC-3626,Streptomyces sp. NRRLWC3626,,periphery
+1463934,Streptomyces sp. NRRL WC-3742,Streptomyces sp. NRRLWC3742,,periphery
+1463936,Streptomyces sp. NRRL WC-3773,Streptomyces sp. NRRLWC3773,,periphery
+1464048,Micromonospora parva,Micromonospora parva,,periphery
+1469245,Thioalkalivibrio sp. HK1,Thioalkalivibrio sp. HK1,,periphery
+1469557,Lacinutrix sp. PAMC 27137,Lacinutrix sp. PAMC27137,,periphery
+1469607,[Scytonema hofmanni] UTEX 2349,Scytonema hofmanni,,periphery
+1469613,Rhodovulum sp. NI22,Rhodovulum sp. NI22,,core
+1469948,Clostridium sp. KNHs209,Clostridium sp. KNHs209,,periphery
+1470591,Sphingomonas sp. RIT328,Sphingomonas sp. RIT328,,periphery
+1470593,Pseudomonas sp. RIT357,Pseudomonas sp. RIT357,,periphery
+1471459,Prochlorococcus sp. scB241_528O2,Prochlorococcus sp. scB241528O2,,periphery
+1471522,Prochlorococcus sp. scB245a_520K10,Prochlorococcus sp. scB245a520K10,,periphery
+1472418,Falsirhodobacter sp. alg1,Falsirhodobacter sp. alg1,,core
+1472716,Burkholderia sp. K24,Burkholderia sp. K24,,periphery
+1473546,Lysinibacillus sp. BF-4,Lysinibacillus sp. BF4,,periphery
+1476583,Deinococcus phoenicis,Deinococcus phoenicis,,periphery
+1476876,Streptomyces sp. NRRL B-24720,Streptomyces sp. NRRLB24720,,periphery
+1476973,Peptostreptococcaceae bacterium VA2,Peptostreptococcaceae bacterium VA2,,periphery
+1479235,Halomonas sp. HL-48,Halomonas sp. HL48,,periphery
+1479237,Marinobacter sp. HL-58,Marinobacter sp. HL58,,core
+1479238,Oceanicaulis sp. HL-87,Oceanicaulis sp. HL87,,periphery
+1479239,Porphyrobacter sp. HL-46,Porphyrobacter sp. HL46,,periphery
+1479623,Curtobacterium sp. S6,Curtobacterium sp. S6,,periphery
+1480694,Spirochaeta sp. JC230,Spirochaeta sp. JC230,,periphery
+1484157,Pantoea sp. PSNIH2,Pantoea sp. PSNIH2,,periphery
+1484158,Pantoea sp. PSNIH1,Pantoea sp. PSNIH1,,periphery
+1484460,Psychroserpens sp. PAMC 27130,Psychroserpens sp. PAMC27130,,core
+1484479,Exiguobacterium sp. AB2,Exiguobacterium sp. AB2,,core
+1485543,Selenomonas sp. AE3005,Selenomonas sp. AE3005,,periphery
+1485544,Ferriphaselus sp. R-1,Ferriphaselus sp. R1,,periphery
+1485545,Zetaproteobacteria bacterium TAG-1,Zetaproteobacteria bacterium TAG1,,periphery
+1487921,Clostridium sp. HMP27,Clostridium sp. HMP27,,periphery
+1487923,Desulfosporosinus sp. HMP52,Desulfosporosinus sp. HMP52,,periphery
+1487953,Leptolyngbya sp. JSC-1,Leptolyngbya sp. JSC1,,periphery
+1487956,Corynebacterium sp. ATCC6931,Corynebacterium sp. ATCC6931,,periphery
+1488328,Pseudomonas sp. Ant30-3,Pseudomonas sp. Ant303,,periphery
+1489678,Deinococcus sp. RL,Deinococcus sp. RL,,core
+1492737,Flavobacterium sp. EM1308,Flavobacterium sp. EM1308,,periphery
+1492738,Flavobacterium sp. EM1321,Flavobacterium sp. EM1321,,periphery
+1492922,Gammaproteobacteria bacterium MFB021,Gammaproteobacteria bacterium MFB021,,core
+1496688,Cyanobium sp. CACIAM 14,Cyanobium sp. CACIAM14,,periphery
+1497679,Listeriaceae bacterium FSL A5-0209,Listeriaceae bacterium FSLA50209,,periphery
+1499498,Prochlorococcus sp. MIT 0601,Prochlorococcus sp. MIT0601,,core
+1499499,Prochlorococcus sp. MIT 0602,Prochlorococcus sp. MIT0602,,core
+1499502,Prochlorococcus sp. MIT 0701,Prochlorococcus sp. MIT0701,,periphery
+1499680,Bacillus sp. MT2,Bacillus sp. MT2,,periphery
+1499683,Clostridium sp. CL-6,Clostridium sp. CL6,,periphery
+1499684,Clostridium sp. CL-2,Clostridium sp. CL2,,periphery
+1499685,Bacillus sp. KW-12,Bacillus sp. KW12,,periphery
+1499686,Pseudomonas sp. 20_BN,Pseudomonas sp. 20BN,,periphery
+1499689,Clostridium sp. LF2,Clostridium sp. LF2,,periphery
+1499967,bacterium UASB270,Bacterium UASB270,,core
+1499968,Paenibacillus sp. TCA20,Paenibacillus sp. TCA20,,periphery
+1500257,Rhizobium sp. YR295,Rhizobium sp. YR295,,periphery
+1500259,Rhizobium sp. YR519,Rhizobium sp. YR519,,periphery
+1500281,Chryseobacterium sp. CF284,Chryseobacterium sp. CF284,,periphery
+1500301,Rhizobium sp. CF097,Rhizobium sp. CF097,,periphery
+1500304,Rhizobium sp. CF394,Rhizobium sp. CF394,,periphery
+1500306,Rhizobium sp. OK494,Rhizobium sp. OK494,,periphery
+1500890,Luteibacter sp. 9143,Luteibacter sp. 9143,,periphery
+1500893,Luteibacter sp. 9135,Luteibacter sp. 9135,,periphery
+1500894,Massilia sp. 9096,Massilia sp. 9096,,periphery
+1500897,Burkholderia sp. 9120,Burkholderia sp. 9120,,periphery
+1501230,Paenibacillus sp. MSt1,Paenibacillus sp. MSt1,,periphery
+1501268,Prochlorococcus sp. MIT 0604,Prochlorococcus sp. MIT0604,,periphery
+1501269,Prochlorococcus sp. MIT 0801,Prochlorococcus sp. MIT0801,,periphery
+1501391,Alistipes sp. 627,Alistipes sp. 627,,periphery
+1502724,Devosia sp. LC5,Devosia sp. LC5,,periphery
+1502770,Methylotenera sp. L2L1,Methylotenera sp. L2L1,,periphery
+1502850,Sphingopyxis sp. LC81,Sphingopyxis sp. LC81,,periphery
+1502851,Bosea sp. LC85,Bosea sp. LC85,,periphery
+1502852,Massilia sp. LC238,Massilia sp. LC238,,periphery
+1504319,actinobacterium acAMD-5,actinobacterium acAMD5,,periphery
+1504672,Polaromonas sp. CG9_12,Polaromonas sp. CG912,,periphery
+1504822,Bacterium sp. OL-1,Bacterium sp. OL1,,periphery
+1504823,Bacterium sp. LF-3,Bacterium sp. LF3,,periphery
+1504981,Halomonas sp. KO116,Halomonas sp. KO116,,periphery
+1506583,Flavobacterium sp. Fl,Flavobacterium sp. Fl,,core
+1506994,Butyrivibrio sp. AE3004,Butyrivibrio sp. AE3004,,periphery
+1508644,Candidatus Arthromitus sp. SFB-mouse-NL,Arthromitus sp. SFBmouseNL,,periphery
+1509403,Acinetobacter sp. HR7,Acinetobacter sp. HR7,,periphery
+1509405,Rhizobium sp. R1-200B2,Rhizobium sp. R1200B2,,periphery
+1510531,Bosea sp. UNC402CLCol,Bosea sp. UNC402CLCol,,periphery
+1514668,Ruminococcus sp. HUN007,Ruminococcus sp. HUN007,,periphery
+1515613,Porphyromonas sp. COT-239_OH1446,Porphyromonas sp. COT239OH1446,,periphery
+1515615,Porphyromonas sp. COT-290_OH860,Porphyromonas sp. COT290OH860,,periphery
+1515746,Shewanella sp. YQH10,Shewanella sp. YQH10,,periphery
+1517416,Idiomarina sp. MCCC 1A10513,Idiomarina sp. MCCC1A10513,,periphery
+1517681,Vibrio sp. ER1A,Vibrio sp. ER1A,,periphery
+1517682,Porphyromonadaceae COT-184_OH4590,Porphyromonadaceae COT184OH4590,,core
+1519439,Oscillibacter sp. ER4,Oscillibacter sp. ER4,,core
+1519464,Chlorobium sp. GBChlB,Chlorobium sp. GBChlB,,periphery
+1521187,Chloroflexus sp. MS-G,Chloroflexus sp. MSG,,periphery
+1522072,Sphingobium sp. ba1,Sphingobium sp. ba1,,periphery
+1523503,Pseudomonas sp. ML96,Pseudomonas sp. ML96,,periphery
+1524467,Serratia sp. Ag1,Serratia sp. Ag1,,periphery
+1525715,Paracoccus sp. 4681,Paracoccus sp. 4681,,periphery
+1526927,Planococcus sp. PAMC 21323,Planococcus sp. PAMC21323,,periphery
+1527444,Candidatus Atelocyanobacterium thalassa isolate SIO64986,Atelocyanobacterium thalassa SIO64986,,core
+1528098,Rickettsiales bacterium Ac37b,Rickettsiales bacterium Ac37b,,core
+1528106,Thalassospira australica,Thalassospira australica,,core
+1530186,Maribius sp. MOLA 401,Maribius sp. MOLA401,,core
+1532557,Achromobacter sp. RTa,Achromobacter sp. RTa,,periphery
+1532558,Rhizobium sp. YS-1r,Rhizobium sp. YS1r,,periphery
+1535287,Devosia sp. 17-2-E-8,Devosia sp. 172E8,,core
+1535422,Thalassotalea sp. ND16A,Thalassotalea sp. ND16A,,core
+1536769,Paenibacillus sp. FSL P4-0081,Paenibacillus sp. FSLP40081,,periphery
+1536770,Paenibacillus sp. FSL R5-0345,Paenibacillus sp. FSLR50345,,periphery
+1536772,Paenibacillus sp. FSL R7-0273,Paenibacillus sp. FSLR70273,,periphery
+1536773,Paenibacillus sp. FSL R7-0331,Paenibacillus sp. FSLR70331,,periphery
+1536774,Paenibacillus sp. FSL H7-0357,Paenibacillus sp. FSLH70357,,periphery
+1536775,Paenibacillus sp. FSL H7-0737,Paenibacillus sp. FSLH70737,,periphery
+1537715,Sphingopyxis sp. MWB1,Sphingopyxis sp. MWB1,,periphery
+1537915,Sulfurospirillum sp. SCADC,Sulfurospirillum sp. SCADC,,periphery
+1537917,Sulfuricurvum sp. MLSB,Sulfuricurvum sp. MLSB,,periphery
+1537994,Alteromonas sp. LOR,Alteromonas sp. LOR,,periphery
+1538295,Aquabacterium sp. NJ1,Aquabacterium sp. NJ1,,core
+1538644,Sphingobacterium sp. ML3W,Sphingobacterium sp. ML3W,,periphery
+1539298,Treponema sp. OMZ 838,Treponema sp. OMZ838,,periphery
+1540221,Deinococcus sp. YIM 77859,Deinococcus sp. YIM77859,,periphery
+1540257,Clostridium sp. KNHs214,Clostridium sp. KNHs214,,periphery
+1541065,Myxosarcina sp. GI1,Myxosarcina sp. GI1,,periphery
+1541959,Mollicutes bacterium HR1,Mollicutes bacterium HR1,,periphery
+1541960,Mollicutes bacterium HR2,Mollicutes bacterium HR2,,core
+1545701,Lactobacillus sp. wkB10,Lactobacillus sp. wkB10,,periphery
+1545702,Lactobacillus sp. wkB8,Lactobacillus sp. wkB8,,periphery
+1545915,Sphingomonas sp. 35-24ZXX,Sphingomonas sp. 3524ZXX,,periphery
+1547437,Hoeflea sp. BAL378,Hoeflea sp. BAL378,,periphery
+1547445,Francisella sp. FSC1006,Francisella sp. FSC1006,,periphery
+1548151,Helicobacter sp. MIT 11-5569,Helicobacter sp. MIT115569,,periphery
+1548153,Campylobacter sp. MIT 97-5078,Campylobacter sp. MIT975078,,periphery
+1549858,Sphingomonas taxi,Sphingomonas taxi,,periphery
+1550073,Sphingomonas sp. 37zxx,Sphingomonas sp. 37zxx,,periphery
+1550091,Sphingobacteriaceae bacterium DW12,Sphingobacteriaceae bacterium DW12,,core
+1552123,Listeriaceae bacterium FSL A5-0281,Listeriaceae bacterium FSLA50281,,core
+1552758,Xanthomonas sp. Nyagatare,Xanthomonas sp. Nyagatare,,periphery
+1561998,Caenorhabditis tropicalis,Caenorhabditis tropicalis,,periphery
+1562701,bacterium endosymbiont of Mortierella elongata FMR23-6,Burkholderiaceae sp. Mortierella,,core
+1565129,Shewanella sp. ECSMB14101,Shewanella sp. ECSMB14101,,periphery
+1565314,Sulfurospirillum sp. MES,Sulfurospirillum sp. MES,,periphery
+1569209,Paracoccus sp. PAMC 22219,Paracoccus sp. PAMC22219,,periphery
+1577887,Dickeya sp. 2B12,Dickeya sp. 2B12,,periphery

--- a/local-setup.Rmd
+++ b/local-setup.Rmd
@@ -1,0 +1,83 @@
+---
+title: "Set up iDEP locally"
+output: github_document
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = TRUE)
+```
+
+```{r, echo = FALSE}
+idep_version <- 93
+port <- 3838
+```
+
+1. (Optional) Download and install docker on your workstation
+
+https://docs.docker.com/get-docker/
+
+2. Pull the docker image
+
+- Download the latest version od the image
+```bash
+docker pull villegar/idep:latest
+```
+
+Alternatively,
+```bash
+docker pull villegar/idep:R-4.0.5
+```
+
+3. Set up global variables and create local directories
+```bash
+IDEP_PATH=/path/to/idep
+IDEP_DATA=/path/to/idep/data
+mkdir -p $IDEP_DATA
+```
+
+<!-- 4. Download the latest version of iDEP from Github -->
+<!-- ```bash -->
+<!-- cd $IDEP_PATH -->
+<!-- git clone https://github.com/iDEP-SDSU/idep -->
+<!-- ``` -->
+
+4. Download the database
+```bash
+cd $IDEP_DATA
+wget https://sdsu.box.com/shared/static/c24f792ojoikpzu0lkpng8uuf9ychwm7.gz -O pathwayDB.tar.gz
+tar xvzf pathwayDB.tar.gz
+rm pathwayDB.tar.gz
+wget https://sdsu.box.com/shared/static/9v1ao6mwhduvrcx793j3answph9gqnkt.gz -O motif.tar.gz
+tar xvzf motif.tar.gz
+rm motif.tar.gz
+wget https://sdsu.box.com/shared/static/mns0k1uvwtfnsohoc89b984ih36nmnz9.gz -O geneInfo.tar.gz
+tar xvzf geneInfo.tar.gz
+rm geneInfo.tar.gz
+wget https://sdsu.box.com/shared/static/qwpdh36vcisgy1hcmadck8i8ezhvr2fh.gz -O data.go.tar.gz
+tar xvzf data.go.tar.gz
+rm data.go.tar.gz
+wget https://sdsu.box.com/shared/static/sorewt7w6iypmhg2k2xhyi8myeit156o.gz -O convertIDs.db.tar.gz
+tar xvzf convertIDs.db.tar.gz
+rm convertIDs.db.tar.gz
+```
+
+5. Deploy a local container
+```bash
+LOCAL_PORT=`r port`
+docker run -dp $LOCAL_PORT:3838 \
+  -v $IDEP_DATA:/srv/data \
+  villegar/idep:latest
+```
+
+
+<!-- ```bash -->
+<!-- LOCAL_PORT=`r port` -->
+<!-- docker run -dp $LOCAL_PORT:3838 \ -->
+<!--   -v $IDEP_DATA:/srv/shiny-server/data \ -->
+<!--   -v $IDEP_PATH:/srv/shiny-server/ \ -->
+<!--   villegar/idep:latest -->
+<!-- ``` -->
+
+6. Open a web browser and navigate to the following URL
+
+http://localhost:`r port`/idep`r idep_version`

--- a/local-setup.Rmd
+++ b/local-setup.Rmd
@@ -12,13 +12,13 @@ idep_version <- 93
 port <- 3838
 ```
 
-1. (Optional) Download and install docker on your workstation
+1. (Optional) Download and install Docker on your workstation
 
 https://docs.docker.com/get-docker/
 
-2. Pull the docker image
+2. Pull the Docker image
 
-- Download the latest version od the image
+- Download the latest version of the image
 ```bash
 docker pull villegar/idep:latest
 ```

--- a/local-setup.Rmd
+++ b/local-setup.Rmd
@@ -59,6 +59,9 @@ rm data.go.tar.gz
 wget https://sdsu.box.com/shared/static/sorewt7w6iypmhg2k2xhyi8myeit156o.gz -O convertIDs.db.tar.gz
 tar xvzf convertIDs.db.tar.gz
 rm convertIDs.db.tar.gz
+
+cd $IDEP_DATA/data_go
+wget https://raw.githubusercontent.com/villegar/idep/master/data/STRING11_species.csv
 ```
 
 5. Deploy a local container

--- a/local-setup.Rmd
+++ b/local-setup.Rmd
@@ -8,8 +8,9 @@ knitr::opts_chunk$set(echo = TRUE)
 ```
 
 ```{r, echo = FALSE}
-idep_version <- 93
-port <- 3838
+IDEP_VERSION <- 93
+DATA_VERSION <- "latest"
+LOCAL_PORT <- 3838
 ```
 
 1. (Optional) Download and install Docker on your workstation
@@ -31,8 +32,10 @@ docker pull villegar/idep:R-4.0.5
 3. Set up global variables and create local directories
 ```bash
 IDEP_PATH=/path/to/idep
-IDEP_DATA=/path/to/idep/data
-mkdir -p $IDEP_DATA
+IDEP_DATA=/path/to/idep/data/
+LOCAL_PORT=`r LOCAL_PORT`
+
+mkdir -p $IDEP_DATA/`r DATA_VERSION`
 ```
 
 <!-- 4. Download the latest version of iDEP from Github -->
@@ -43,7 +46,7 @@ mkdir -p $IDEP_DATA
 
 4. Download the database
 ```bash
-cd $IDEP_DATA
+cd $IDEP_DATA/`r DATA_VERSION`
 wget https://sdsu.box.com/shared/static/c24f792ojoikpzu0lkpng8uuf9ychwm7.gz -O pathwayDB.tar.gz
 tar xvzf pathwayDB.tar.gz
 rm pathwayDB.tar.gz
@@ -66,7 +69,6 @@ wget https://raw.githubusercontent.com/villegar/idep/master/data/STRING11_specie
 
 5. Deploy a local container
 ```bash
-LOCAL_PORT=`r port`
 docker run -dp $LOCAL_PORT:3838 \
   -v $IDEP_DATA:/srv/data \
   villegar/idep:latest
@@ -74,7 +76,7 @@ docker run -dp $LOCAL_PORT:3838 \
 
 
 <!-- ```bash -->
-<!-- LOCAL_PORT=`r port` -->
+<!-- LOCAL_PORT=`r LOCAL_PORT` -->
 <!-- docker run -dp $LOCAL_PORT:3838 \ -->
 <!--   -v $IDEP_DATA:/srv/shiny-server/data \ -->
 <!--   -v $IDEP_PATH:/srv/shiny-server/ \ -->
@@ -83,4 +85,4 @@ docker run -dp $LOCAL_PORT:3838 \
 
 6. Open a web browser and navigate to the following URL
 
-http://localhost:`r port`/idep`r idep_version`
+http://localhost:`r LOCAL_PORT`/idep`r IDEP_VERSION`

--- a/local-setup.Rmd
+++ b/local-setup.Rmd
@@ -8,8 +8,8 @@ knitr::opts_chunk$set(echo = TRUE)
 ```
 
 ```{r, echo = FALSE}
-IDEP_VERSION <- 93
-DATA_VERSION <- "latest"
+IDEP_VERSION <- 94
+DATA_VERSION <- "data104"
 LOCAL_PORT <- 3838
 ```
 
@@ -31,7 +31,7 @@ docker pull villegar/idep:R-4.0.5
 
 3. Set up global variables and create local directories
 ```bash
-IDEP_PATH=/path/to/idep
+IDEP_PATH=/path/to/idep/idep`r IDEP_VERSION`
 IDEP_DATA=/path/to/idep/data/
 LOCAL_PORT=`r LOCAL_PORT`
 
@@ -44,36 +44,55 @@ mkdir -p $IDEP_DATA/`r DATA_VERSION`
 <!-- git clone https://github.com/iDEP-SDSU/idep -->
 <!-- ``` -->
 
-4. Download the database
+4. Download and extract the database
 ```bash
-cd $IDEP_DATA/`r DATA_VERSION`
-wget https://sdsu.box.com/shared/static/c24f792ojoikpzu0lkpng8uuf9ychwm7.gz -O pathwayDB.tar.gz
-tar xvzf pathwayDB.tar.gz
-rm pathwayDB.tar.gz
-wget https://sdsu.box.com/shared/static/9v1ao6mwhduvrcx793j3answph9gqnkt.gz -O motif.tar.gz
-tar xvzf motif.tar.gz
-rm motif.tar.gz
-wget https://sdsu.box.com/shared/static/mns0k1uvwtfnsohoc89b984ih36nmnz9.gz -O geneInfo.tar.gz
-tar xvzf geneInfo.tar.gz
-rm geneInfo.tar.gz
-wget https://sdsu.box.com/shared/static/qwpdh36vcisgy1hcmadck8i8ezhvr2fh.gz -O data.go.tar.gz
-tar xvzf data.go.tar.gz
-rm data.go.tar.gz
-wget https://sdsu.box.com/shared/static/sorewt7w6iypmhg2k2xhyi8myeit156o.gz -O convertIDs.db.tar.gz
-tar xvzf convertIDs.db.tar.gz
-rm convertIDs.db.tar.gz
-
-cd $IDEP_DATA/data_go
-wget https://raw.githubusercontent.com/villegar/idep/master/data/STRING11_species.csv
+wget https://mft.sdstate.edu/public/file/3Y66fppA0Eym0G41taPtRw/data104.tar.gz -O data104.tar.gz
+tar xvzf data104.tar.gz --directory $IDEP_DATA/../
+rm data104.tar.gz
 ```
 
-5. Deploy a local container
+<!-- ```bash -->
+<!-- cd $IDEP_DATA/`r DATA_VERSION` -->
+<!-- wget https://sdsu.box.com/shared/static/c24f792ojoikpzu0lkpng8uuf9ychwm7.gz -O pathwayDB.tar.gz -->
+<!-- tar xvzf pathwayDB.tar.gz -->
+<!-- rm pathwayDB.tar.gz -->
+<!-- wget https://sdsu.box.com/shared/static/9v1ao6mwhduvrcx793j3answph9gqnkt.gz -O motif.tar.gz -->
+<!-- tar xvzf motif.tar.gz -->
+<!-- rm motif.tar.gz -->
+<!-- wget https://sdsu.box.com/shared/static/mns0k1uvwtfnsohoc89b984ih36nmnz9.gz -O geneInfo.tar.gz -->
+<!-- tar xvzf geneInfo.tar.gz -->
+<!-- rm geneInfo.tar.gz -->
+<!-- wget https://sdsu.box.com/shared/static/qwpdh36vcisgy1hcmadck8i8ezhvr2fh.gz -O data.go.tar.gz -->
+<!-- tar xvzf data.go.tar.gz -->
+<!-- rm data.go.tar.gz -->
+<!-- wget https://sdsu.box.com/shared/static/sorewt7w6iypmhg2k2xhyi8myeit156o.gz -O convertIDs.db.tar.gz -->
+<!-- tar xvzf convertIDs.db.tar.gz -->
+<!-- rm convertIDs.db.tar.gz -->
+
+<!-- cd $IDEP_DATA/data_go -->
+<!-- wget https://raw.githubusercontent.com/villegar/idep/master/data/STRING11_species.csv -->
+<!-- ``` -->
+
+5. Download the latest version of iDEP from GitHub:
+```bash
+git clone https://github.com/iDEP-SDSU/idep $IDEP_PATH
+```
+
+6. Deploy a local container
 ```bash
 docker run -dp $LOCAL_PORT:3838 \
   -v $IDEP_DATA:/srv/data \
+  -v $IDEP_PATH/shinyapps:/srv/shiny-server \
   villegar/idep:latest
 ```
 
+Alternatively,
+```bash
+docker run -dp $LOCAL_PORT:3838 \
+  -v $IDEP_DATA:/srv/data \
+  -v $IDEP_PATH/shinyapps:/srv/shiny-server \
+  villegar/idep:R-4.0.5
+```
 
 <!-- ```bash -->
 <!-- LOCAL_PORT=`r LOCAL_PORT` -->
@@ -83,6 +102,6 @@ docker run -dp $LOCAL_PORT:3838 \
 <!--   villegar/idep:latest -->
 <!-- ``` -->
 
-6. Open a web browser and navigate to the following URL
+7. Open a web browser and navigate to the following URL
 
 http://localhost:`r LOCAL_PORT`/idep`r IDEP_VERSION`

--- a/local-setup.md
+++ b/local-setup.md
@@ -28,11 +28,11 @@ docker pull villegar/idep:R-4.0.5
 <!-- end list -->
 
 ``` bash
-IDEP_PATH=/path/to/idep
+IDEP_PATH=/path/to/idep/idep94
 IDEP_DATA=/path/to/idep/data/
 LOCAL_PORT=3838
 
-mkdir -p $IDEP_DATA/latest
+mkdir -p $IDEP_DATA/data104
 ```
 
 <!-- 4. Download the latest version of iDEP from Github -->
@@ -45,40 +45,82 @@ mkdir -p $IDEP_DATA/latest
 
 <!-- ``` -->
 
-4.  Download the database
+4.  Download and extract the database
 
 <!-- end list -->
 
 ``` bash
-cd $IDEP_DATA/latest
-wget https://sdsu.box.com/shared/static/c24f792ojoikpzu0lkpng8uuf9ychwm7.gz -O pathwayDB.tar.gz
-tar xvzf pathwayDB.tar.gz
-rm pathwayDB.tar.gz
-wget https://sdsu.box.com/shared/static/9v1ao6mwhduvrcx793j3answph9gqnkt.gz -O motif.tar.gz
-tar xvzf motif.tar.gz
-rm motif.tar.gz
-wget https://sdsu.box.com/shared/static/mns0k1uvwtfnsohoc89b984ih36nmnz9.gz -O geneInfo.tar.gz
-tar xvzf geneInfo.tar.gz
-rm geneInfo.tar.gz
-wget https://sdsu.box.com/shared/static/qwpdh36vcisgy1hcmadck8i8ezhvr2fh.gz -O data.go.tar.gz
-tar xvzf data.go.tar.gz
-rm data.go.tar.gz
-wget https://sdsu.box.com/shared/static/sorewt7w6iypmhg2k2xhyi8myeit156o.gz -O convertIDs.db.tar.gz
-tar xvzf convertIDs.db.tar.gz
-rm convertIDs.db.tar.gz
-
-cd $IDEP_DATA/data_go
-wget https://raw.githubusercontent.com/villegar/idep/master/data/STRING11_species.csv
+wget https://mft.sdstate.edu/public/file/3Y66fppA0Eym0G41taPtRw/data104.tar.gz -O data104.tar.gz
+tar xvzf data104.tar.gz --directory $IDEP_DATA/../
+rm data104.tar.gz
 ```
 
-5.  Deploy a local container
+<!-- ```bash -->
+
+<!-- cd $IDEP_DATA/data104 -->
+
+<!-- wget https://sdsu.box.com/shared/static/c24f792ojoikpzu0lkpng8uuf9ychwm7.gz -O pathwayDB.tar.gz -->
+
+<!-- tar xvzf pathwayDB.tar.gz -->
+
+<!-- rm pathwayDB.tar.gz -->
+
+<!-- wget https://sdsu.box.com/shared/static/9v1ao6mwhduvrcx793j3answph9gqnkt.gz -O motif.tar.gz -->
+
+<!-- tar xvzf motif.tar.gz -->
+
+<!-- rm motif.tar.gz -->
+
+<!-- wget https://sdsu.box.com/shared/static/mns0k1uvwtfnsohoc89b984ih36nmnz9.gz -O geneInfo.tar.gz -->
+
+<!-- tar xvzf geneInfo.tar.gz -->
+
+<!-- rm geneInfo.tar.gz -->
+
+<!-- wget https://sdsu.box.com/shared/static/qwpdh36vcisgy1hcmadck8i8ezhvr2fh.gz -O data.go.tar.gz -->
+
+<!-- tar xvzf data.go.tar.gz -->
+
+<!-- rm data.go.tar.gz -->
+
+<!-- wget https://sdsu.box.com/shared/static/sorewt7w6iypmhg2k2xhyi8myeit156o.gz -O convertIDs.db.tar.gz -->
+
+<!-- tar xvzf convertIDs.db.tar.gz -->
+
+<!-- rm convertIDs.db.tar.gz -->
+
+<!-- cd $IDEP_DATA/data_go -->
+
+<!-- wget https://raw.githubusercontent.com/villegar/idep/master/data/STRING11_species.csv -->
+
+<!-- ``` -->
+
+5.  Download the latest version of iDEP from GitHub:
+
+<!-- end list -->
+
+``` bash
+git clone https://github.com/iDEP-SDSU/idep $IDEP_PATH
+```
+
+6.  Deploy a local container
 
 <!-- end list -->
 
 ``` bash
 docker run -dp $LOCAL_PORT:3838 \
   -v $IDEP_DATA:/srv/data \
+  -v $IDEP_PATH/shinyapps:/srv/shiny-server \
   villegar/idep:latest
+```
+
+Alternatively,
+
+``` bash
+docker run -dp $LOCAL_PORT:3838 \
+  -v $IDEP_DATA:/srv/data \
+  -v $IDEP_PATH/shinyapps:/srv/shiny-server \
+  villegar/idep:R-4.0.5
 ```
 
 <!-- ```bash -->
@@ -95,6 +137,6 @@ docker run -dp $LOCAL_PORT:3838 \
 
 <!-- ``` -->
 
-6.  Open a web browser and navigate to the following URL
+7.  Open a web browser and navigate to the following URL
 
-<http://localhost:3838/idep93>
+<http://localhost:3838/idep94>

--- a/local-setup.md
+++ b/local-setup.md
@@ -1,0 +1,97 @@
+Set up iDEP locally
+================
+
+1.  (Optional) Download and install docker on your workstation
+
+<https://docs.docker.com/get-docker/>
+
+2.  Pull the docker image
+
+<!-- end list -->
+
+  - Download the latest version od the image
+
+<!-- end list -->
+
+``` bash
+docker pull villegar/idep:latest
+```
+
+Alternatively,
+
+``` bash
+docker pull villegar/idep:R-4.0.5
+```
+
+3.  Set up global variables and create local directories
+
+<!-- end list -->
+
+``` bash
+IDEP_PATH=/path/to/idep
+IDEP_DATA=/path/to/idep/data
+mkdir -p $IDEP_DATA
+```
+
+<!-- 4. Download the latest version of iDEP from Github -->
+
+<!-- ```bash -->
+
+<!-- cd $IDEP_PATH -->
+
+<!-- git clone https://github.com/iDEP-SDSU/idep -->
+
+<!-- ``` -->
+
+4.  Download the database
+
+<!-- end list -->
+
+``` bash
+cd $IDEP_DATA
+wget https://sdsu.box.com/shared/static/c24f792ojoikpzu0lkpng8uuf9ychwm7.gz -O pathwayDB.tar.gz
+tar xvzf pathwayDB.tar.gz
+rm pathwayDB.tar.gz
+wget https://sdsu.box.com/shared/static/9v1ao6mwhduvrcx793j3answph9gqnkt.gz -O motif.tar.gz
+tar xvzf motif.tar.gz
+rm motif.tar.gz
+wget https://sdsu.box.com/shared/static/mns0k1uvwtfnsohoc89b984ih36nmnz9.gz -O geneInfo.tar.gz
+tar xvzf geneInfo.tar.gz
+rm geneInfo.tar.gz
+wget https://sdsu.box.com/shared/static/qwpdh36vcisgy1hcmadck8i8ezhvr2fh.gz -O data.go.tar.gz
+tar xvzf data.go.tar.gz
+rm data.go.tar.gz
+wget https://sdsu.box.com/shared/static/sorewt7w6iypmhg2k2xhyi8myeit156o.gz -O convertIDs.db.tar.gz
+tar xvzf convertIDs.db.tar.gz
+rm convertIDs.db.tar.gz
+```
+
+5.  Deploy a local container
+
+<!-- end list -->
+
+``` bash
+LOCAL_PORT=3838
+docker run -dp $LOCAL_PORT:3838 \
+  -v $IDEP_DATA:/srv/shiny-server/data \
+  -v $IDEP_PATH:/srv/shiny-server/ \
+  villegar/idep:latest
+```
+
+<!-- ```bash -->
+
+<!-- LOCAL_PORT=3838 -->
+
+<!-- docker run -dp $LOCAL_PORT:3838 \ -->
+
+<!--   -v $IDEP_DATA:/srv/shiny-server/data \ -->
+
+<!--   -v $IDEP_PATH:/srv/shiny-server/ \ -->
+
+<!--   villegar/idep:latest -->
+
+<!-- ``` -->
+
+6.  Open a web browser and navigate to the following URL
+
+<http://localhost:3838/idep93>

--- a/local-setup.md
+++ b/local-setup.md
@@ -1,15 +1,15 @@
 Set up iDEP locally
 ================
 
-1.  (Optional) Download and install docker on your workstation
+1.  (Optional) Download and install Docker on your workstation
 
 <https://docs.docker.com/get-docker/>
 
-2.  Pull the docker image
+2.  Pull the Docker image
 
 <!-- end list -->
 
-  - Download the latest version od the image
+  - Download the latest version of the image
 
 <!-- end list -->
 
@@ -73,8 +73,7 @@ rm convertIDs.db.tar.gz
 ``` bash
 LOCAL_PORT=3838
 docker run -dp $LOCAL_PORT:3838 \
-  -v $IDEP_DATA:/srv/shiny-server/data \
-  -v $IDEP_PATH:/srv/shiny-server/ \
+  -v $IDEP_DATA:/srv/data \
   villegar/idep:latest
 ```
 

--- a/local-setup.md
+++ b/local-setup.md
@@ -64,6 +64,9 @@ rm data.go.tar.gz
 wget https://sdsu.box.com/shared/static/sorewt7w6iypmhg2k2xhyi8myeit156o.gz -O convertIDs.db.tar.gz
 tar xvzf convertIDs.db.tar.gz
 rm convertIDs.db.tar.gz
+
+cd $IDEP_DATA/data_go
+wget https://raw.githubusercontent.com/villegar/idep/master/data/STRING11_species.csv
 ```
 
 5.  Deploy a local container

--- a/local-setup.md
+++ b/local-setup.md
@@ -29,8 +29,10 @@ docker pull villegar/idep:R-4.0.5
 
 ``` bash
 IDEP_PATH=/path/to/idep
-IDEP_DATA=/path/to/idep/data
-mkdir -p $IDEP_DATA
+IDEP_DATA=/path/to/idep/data/
+LOCAL_PORT=3838
+
+mkdir -p $IDEP_DATA/latest
 ```
 
 <!-- 4. Download the latest version of iDEP from Github -->
@@ -48,7 +50,7 @@ mkdir -p $IDEP_DATA
 <!-- end list -->
 
 ``` bash
-cd $IDEP_DATA
+cd $IDEP_DATA/latest
 wget https://sdsu.box.com/shared/static/c24f792ojoikpzu0lkpng8uuf9ychwm7.gz -O pathwayDB.tar.gz
 tar xvzf pathwayDB.tar.gz
 rm pathwayDB.tar.gz
@@ -74,7 +76,6 @@ wget https://raw.githubusercontent.com/villegar/idep/master/data/STRING11_specie
 <!-- end list -->
 
 ``` bash
-LOCAL_PORT=3838
 docker run -dp $LOCAL_PORT:3838 \
   -v $IDEP_DATA:/srv/data \
   villegar/idep:latest

--- a/shinyapps/idep/server.R
+++ b/shinyapps/idep/server.R
@@ -90,7 +90,7 @@ maxSamplesEDAplot = 100  # max number of samples for EDA plots
 ################################################################
 
 # relative path to data files
-datapath = "../../data/data95/"   # production server
+datapath = Sys.getenv("IDEP_DATA", "/srv/data/latest")   # production server
 
 sqlite  <- dbDriver("SQLite")
 convert <- dbConnect( sqlite, paste0(datapath, "convertIDs.db"), flags=SQLITE_RO)  #read only mode

--- a/shinyapps/idep93/server.R
+++ b/shinyapps/idep93/server.R
@@ -91,7 +91,8 @@ STRING_DB_VERSION <- "11.0" # what version of STRINGdb needs to be used
 ################################################################
 
 # relative path to data files
-datapath = Sys.getenv("IDEP_DATA", "../../data/data100/")   # production server
+datapath = Sys.getenv("IDEP_DATA", "/srv/data")   # production server
+
 
 sqlite  <- dbDriver("SQLite")
 convert <- dbConnect( sqlite, paste0(datapath, "convertIDs.db"), flags=SQLITE_RO)  #read only mode

--- a/shinyapps/idep93/server.R
+++ b/shinyapps/idep93/server.R
@@ -91,7 +91,7 @@ STRING_DB_VERSION <- "11.0" # what version of STRINGdb needs to be used
 ################################################################
 
 # relative path to data files
-datapath = "../../data/data100/"   # production server
+datapath = Sys.getenv("IDEP_DATA", "../../data/data100/")   # production server
 
 sqlite  <- dbDriver("SQLite")
 convert <- dbConnect( sqlite, paste0(datapath, "convertIDs.db"), flags=SQLITE_RO)  #read only mode

--- a/shinyapps/idep93/server.R
+++ b/shinyapps/idep93/server.R
@@ -91,7 +91,7 @@ STRING_DB_VERSION <- "11.0" # what version of STRINGdb needs to be used
 ################################################################
 
 # relative path to data files
-datapath = Sys.getenv("IDEP_DATA", "/srv/data")   # production server
+datapath = Sys.getenv("IDEP_DATA", "/srv/data/latest")   # production server
 
 
 sqlite  <- dbDriver("SQLite")


### PR DESCRIPTION
The container should be rebuilt and re-uploaded for these instructions to work. However, a small tweak can be done, so the instructions will work with the current version (iDEP 93):

After downloading the database and related files, run the following:
```bash
cd $IDEP_DATA
ln -sf latest data103 
```
This will create a symbolic link to the `latest` version of the data, called `data103`, from which iDEP version 93 (https://github.com/iDEP-SDSU/idep/blob/master/shinyapps/idep93) (inside the Docker image) tries to read the data 
```R
datapath = "../../data/data103/"
```