### PR TITLE
Fix large empty border around iDEP UI

### DIFF
--- a/shinyapps/idep94/ui.R
+++ b/shinyapps/idep94/ui.R
@@ -28,10 +28,22 @@ iDEPversion,
     sidebarPanel(
   
       actionButton("goButton", "Click here to load demo data"),
-      tags$head(tags$style("#goButton{color: red;
-                                 font-size: 16px;
-                                 font-style: italic;
-                                 }"))                    
+      tags$head(
+        # Example Button style 
+        tags$style("
+          #goButton{
+            color: red;
+            font-size: 16px;
+            font-style: italic;
+          }"
+        ),
+        # Fix excessive padding around the body 
+        tags$style("
+          body {
+            padding: 0 !important;
+          }"
+        )
+      )
       ,h5(" and just click the tabs for some magic!", style = "color:red")
       ,p(HTML("<div align=\"right\"> <A HREF=\"javascript:history.go(0)\">Reset</A></div>" ))
       ,strong("1. Optional:Select or search for your species.")


### PR DESCRIPTION
I have since few commits a really large empty border around the body of iDEP, even above the tab selector...
I don't know if it's intentional, but if not, this will fix this problem