### PR TITLE
bug caused single gene plot not working in iDEP 95

### DIFF
--- a/shinyapps/idep94/server.R
+++ b/shinyapps/idep94/server.R
@@ -796,6 +796,7 @@ geneInfo <- function (converted,selectOrg){
 	if(length(ix) == 1)  # if only one file           #WBGene0000001 some ensembl gene ids in lower case
 	{ x = read.csv(as.character(geneInfoFiles[ix]) ); 
       x[,1]= toupper(x[,1]) 
+	  x$symbol <- gsub(" ", "", x$symbol) # remove spaces before gene symbol
       # if symbol is missing use Ensembl IDs
       x$symbol[ is.na( x$symbol) ] <- x[, 1]
       # if duplicated symbol, paste Ensembl id to the end

--- a/shinyapps/idep95/server.R
+++ b/shinyapps/idep95/server.R
@@ -795,7 +795,8 @@ geneInfo <- function (converted,selectOrg){
 	}
 	if(length(ix) == 1)  # if only one file           #WBGene0000001 some ensembl gene ids in lower case
 	{ x = read.csv(as.character(geneInfoFiles[ix]) ); 
-      x[,1]= toupper(x[,1]) 
+      x[,1]= toupper(x[,1])
+	  x$symbol <- gsub(" ", "", x$symbol) # remove spaces before gene symbol
       # if symbol is missing use Ensembl IDs
       x$symbol[ is.na( x$symbol) ] <- x[, 1]
       # if duplicated symbol, paste Ensembl id to the end


### PR DESCRIPTION
Space characters are put in the front of gene symbols to avoid auto-conversion by Excel.
Two in data104, but three in data104b.