### PR TITLE
Update data104 to data104b

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -25,8 +25,8 @@ echo 'Docker images have been built. Start downloading data.'
 
 mkdir data
 cd data
-mkdir data104
-cd data104
+mkdir data104b
+cd data104b
 
 
 wget http://bioinformatics.sdstate.edu/data/current_version/convertIDs.db.tar.gz


### PR DESCRIPTION
Hi! We had some issues with the setup.sh script putting the databases into data/data104 instead of data/data104b. This little patch should fix it. This is also referred to in #168. Thanks!